### PR TITLE
Fix CSRF token on login page

### DIFF
--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -8,6 +8,7 @@
 </head>
 <body class="login-background d-flex align-items-center justify-content-center vh-100">
     <form method="POST" class="p-4 bg-white rounded shadow" style="width: 100%; max-width: 400px;">
+        {{ csrf_token() }}
         <h3 class="mb-3 text-center">Bejelentkezés</h3>
         <div class="mb-3">
             <input type="text" class="form-control" name="username" placeholder="Felhasználónév" required>


### PR DESCRIPTION
## Summary
- ensure CSRF token is included in login form to avoid Bad Request error

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684931c65680832a9783377d88a7b70f