### PR TITLE
Fix CSRF token error on login

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -1,5 +1,12 @@
 from flask_wtf import FlaskForm
-from wtforms import StringField, DateField, IntegerField, SubmitField, SelectField
+from wtforms import (
+    StringField,
+    DateField,
+    IntegerField,
+    SubmitField,
+    SelectField,
+    PasswordField,
+)
 from wtforms.validators import DataRequired, NumberRange
 
 class PassForm(FlaskForm):
@@ -9,3 +16,9 @@ class PassForm(FlaskForm):
     total_uses = IntegerField('Alkalmak száma', validators=[DataRequired(), NumberRange(min=1)])
     user_id = SelectField('Felhasználó', coerce=int, validators=[DataRequired()])
     submit = SubmitField('Bérlet létrehozása')
+
+
+class LoginForm(FlaskForm):
+    username = StringField('Felhasználónév', validators=[DataRequired()])
+    password = PasswordField('Jelszó', validators=[DataRequired()])
+    submit = SubmitField('Bejelentkezés')

--- a/app/routes/auth_routes.py
+++ b/app/routes/auth_routes.py
@@ -2,21 +2,23 @@ from flask import Blueprint, render_template, redirect, url_for, flash, request
 from flask_login import login_user, logout_user, login_required
 from ..models import User
 from werkzeug.security import check_password_hash
+from ..forms import LoginForm
 
 auth_bp = Blueprint('auth', __name__)
 
 @auth_bp.route('/login', methods=['GET', 'POST'])
 def login():
-    if request.method == 'POST':
-        username = request.form['username']
-        password = request.form['password']
+    form = LoginForm()
+    if form.validate_on_submit():
+        username = form.username.data
+        password = form.password.data
 
         user = User.query.filter_by(username=username).first()
         if user and check_password_hash(user.password_hash, password):
             login_user(user)
             return redirect(url_for('user.dashboard'))
         flash('Hibás felhasználónév vagy jelszó.')
-    return render_template('login.html')
+    return render_template('login.html', form=form)
 
 @auth_bp.route('/logout')
 @login_required

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -8,14 +8,15 @@
 </head>
 <body class="login-background d-flex align-items-center justify-content-center vh-100">
     <form method="POST" class="p-4 bg-white rounded shadow" style="width: 100%; max-width: 400px;">
+        {{ form.hidden_tag() }}
         <h3 class="mb-3 text-center">Bejelentkezés</h3>
         <div class="mb-3">
-            <input type="text" class="form-control" name="username" placeholder="Felhasználónév" required>
+            {{ form.username(class="form-control", placeholder="Felhasználónév") }}
         </div>
         <div class="mb-3">
-            <input type="password" class="form-control" name="password" placeholder="Jelszó" required>
+            {{ form.password(class="form-control", placeholder="Jelszó") }}
         </div>
-        <button type="submit" class="btn btn-primary w-100">Bejelentkezés</button>
+        {{ form.submit(class="btn btn-primary w-100") }}
     </form>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add LoginForm to handle CSRF token for the login page
- update login route to use LoginForm and pass it to template
- update login template to render fields via WTForms

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684932b84ca4832ab4d0be4bdcb6208b