### PR TITLE
Fix CSRF token missing during login

### DIFF
--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -8,6 +8,7 @@
 </head>
 <body class="login-background d-flex align-items-center justify-content-center vh-100">
     <form method="POST" class="p-4 bg-white rounded shadow" style="width: 100%; max-width: 400px;">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
         <h3 class="mb-3 text-center">Bejelentkezés</h3>
         <div class="mb-3">
             <input type="text" class="form-control" name="username" placeholder="Felhasználónév" required>


### PR DESCRIPTION
## Summary
- include hidden CSRF token field in login form

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68493127fbb8832aa936495f6fc6eb16