### PR TITLE
Fix login page form variable

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -1,6 +1,13 @@
 from flask_wtf import FlaskForm
-from wtforms import (StringField, DateField, IntegerField, SubmitField,
-                     SelectField, TextAreaField)
+from wtforms import (
+    StringField,
+    PasswordField,
+    DateField,
+    IntegerField,
+    SubmitField,
+    SelectField,
+    TextAreaField,
+)
 from wtforms.validators import DataRequired, NumberRange
 
 class PassForm(FlaskForm):
@@ -19,3 +26,9 @@ class UserForm(FlaskForm):
     password = StringField('Jelszó', validators=[DataRequired()])
     role = SelectField('Szerep', choices=[('user', 'User'), ('admin', 'Admin')], validators=[DataRequired()])
     submit = SubmitField('Mentés')
+
+
+class LoginForm(FlaskForm):
+    username = StringField('Felhasználónév', validators=[DataRequired()])
+    password = PasswordField('Jelszó', validators=[DataRequired()])
+    submit = SubmitField('Bejelentkezés')

--- a/app/routes/auth_routes.py
+++ b/app/routes/auth_routes.py
@@ -2,21 +2,23 @@ from flask import Blueprint, render_template, redirect, url_for, flash, request
 from flask_login import login_user, logout_user, login_required
 from ..models import User
 from werkzeug.security import check_password_hash
+from ..forms import LoginForm
 
 auth_bp = Blueprint('auth', __name__)
 
 @auth_bp.route('/login', methods=['GET', 'POST'])
 def login():
-    if request.method == 'POST':
-        username = request.form['username']
-        password = request.form['password']
+    form = LoginForm()
+    if form.validate_on_submit():
+        username = form.username.data
+        password = form.password.data
 
         user = User.query.filter_by(username=username).first()
         if user and check_password_hash(user.password_hash, password):
             login_user(user)
             return redirect(url_for('user.dashboard'))
         flash('Hibás felhasználónév vagy jelszó.')
-    return render_template('login.html')
+    return render_template('login.html', form=form)
 
 @auth_bp.route('/logout')
 @login_required


### PR DESCRIPTION
## Summary
- add `LoginForm` to manage login fields
- use `LoginForm` in `login` route and pass `form` to template

## Testing
- `python3 -m py_compile app/forms.py app/routes/auth_routes.py`
- `python3 run.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68493ab1c0f4832a9db872e1add76ab5