### PR TITLE
Fix detached session error on pass deletion

### DIFF
--- a/app/routes/admin_routes.py
+++ b/app/routes/admin_routes.py
@@ -76,12 +76,21 @@ def delete_pass(pass_id):
         return redirect(url_for('user.dashboard'))
 
     selected_pass = Pass.query.get_or_404(pass_id)
+    # collect details before deleting because the instance will be detached from
+    # the session after deletion and commit
+    user_name = selected_pass.user.username
+    user_email = selected_pass.user.email
+    pass_type = selected_pass.type
+    start_date = selected_pass.start_date
+    end_date = selected_pass.end_date
+    used = selected_pass.used
+
     db.session.delete(selected_pass)
     db.session.commit()
     send_email(
         "Bérlet törölve",
-        pass_deleted_email(selected_pass.user.username, selected_pass.type, selected_pass.start_date, selected_pass.end_date, selected_pass.used),
-        selected_pass.user.email,
+        pass_deleted_email(user_name, pass_type, start_date, end_date, used),
+        user_email,
     )
     flash("Bérlet törölve.", "success")
     return redirect(url_for('user.dashboard'))


### PR DESCRIPTION
## Summary
- gather pass details before removing from db
- use gathered values when sending email after deletion

## Testing
- `python -m py_compile app/routes/admin_routes.py`


------
https://chatgpt.com/codex/tasks/task_e_684942daefac832ab60da89ffcbf1c40