### PR TITLE
Improve admin pass management UI

### DIFF
--- a/app/routes/admin_routes.py
+++ b/app/routes/admin_routes.py
@@ -67,7 +67,7 @@ def extend_pass(pass_id):
         flash("Bérlet módosítva.", "success")
         return redirect(url_for('admin.verify_pass', pass_id=p.id))
 
-    return render_template('extend_pass.html', form=form)
+    return render_template('extend_pass.html', form=form, pass_id=pass_id)
 
 @admin_bp.route('/delete_pass/<int:pass_id>')
 @login_required

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -31,9 +31,12 @@
                         <h5 class="card-title">{{ p.type }}</h5>
                         <p class="card-text">{{ p.start_date }} - {{ p.end_date }}</p>
                         <p class="card-text">Alkalmak: {{ p.used }} / {{ p.total_uses }}</p>
+                        {% if user.role == 'admin' %}
+                        <p class="card-text">Felhasználó: {{ p.user.username }}</p>
+                        {% endif %}
                         {% if p.comment %}<p class="card-text"><small>{{ p.comment }}</small></p>{% endif %}
                         {% if user.role == 'admin' %}
-                            <a href="{{ url_for('admin.verify_pass', pass_id=p.id) }}" class="btn btn-sm btn-warning">Ellenőrzés</a>
+                            <a href="{{ url_for('admin.verify_pass', pass_id=p.id) }}" class="btn btn-sm btn-warning">Szerkesztés</a>
                             <a href="{{ url_for('admin.delete_pass', pass_id=p.id) }}" class="btn btn-sm btn-danger">Törlés</a>
                         {% endif %}
                     </div>

--- a/app/templates/extend_pass.html
+++ b/app/templates/extend_pass.html
@@ -17,6 +17,7 @@
         <div class="mb-3">{{ form.user_id.label }} {{ form.user_id(class="form-select") }}</div>
         <div class="mb-3">{{ form.comment.label }} {{ form.comment(class="form-control") }}</div>
         <div class="mb-3">{{ form.submit(class="btn btn-primary") }}</div>
+        <a href="{{ url_for('admin.verify_pass', pass_id=pass_id) }}" class="btn btn-secondary">Visszalépés</a>
     </form>
 </div>
 </body>

--- a/app/templates/users.html
+++ b/app/templates/users.html
@@ -9,6 +9,7 @@
 <div class="container mt-5">
     <h3>Felhasználók</h3>
     <a href="{{ url_for('admin.create_user') }}" class="btn btn-success btn-sm mb-3">Új felhasználó</a>
+    <a href="{{ url_for('user.dashboard') }}" class="btn btn-secondary btn-sm mb-3">Visszalépés</a>
     <table class="table table-striped">
         <thead>
             <tr><th>ID</th><th>Név</th><th>Email</th><th>Szerep</th><th></th></tr>

--- a/app/templates/verify_pass.html
+++ b/app/templates/verify_pass.html
@@ -22,7 +22,7 @@
                 {% endif %}
                 <div class="mt-3">
                     <a href="{{ url_for('admin.use_pass', pass_id=p.id) }}" class="btn btn-success btn-sm">Alkalom hozzáadása</a>
-                    <a href="{{ url_for('admin.undo_use', pass_id=p.id) }}" class="btn btn-secondary btn-sm">Visszavonás</a>
+                    <a href="{{ url_for('admin.undo_use', pass_id=p.id) }}" class="btn btn-secondary btn-sm">Alkalom visszavonása</a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- show pass owner name on admin dashboard cards
- rename *Ellenőrzés* action to *Szerkesztés*
- rename undo action to *Alkalom visszavonása*
- add back buttons to pass edit and user list pages
- supply pass id to edit template

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684944766e7c832aaab920060ada7bfb