### PR TITLE
Add back link on verify pass page

### DIFF
--- a/app/templates/verify_pass.html
+++ b/app/templates/verify_pass.html
@@ -23,6 +23,7 @@
                 <div class="mt-3">
                     <a href="{{ url_for('admin.use_pass', pass_id=p.id) }}" class="btn btn-success btn-sm">Alkalom hozzáadása</a>
                     <a href="{{ url_for('admin.undo_use', pass_id=p.id) }}" class="btn btn-secondary btn-sm">Alkalom visszavonása</a>
+                    <a href="{{ url_for('user.dashboard') }}" class="btn btn-secondary btn-sm">Visszalépés</a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- add a Back button on the pass verification page to return to the admin dashboard

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6849459f1cf0832aaad3228336c7b619