### PR TITLE
Apply login background globally

### DIFF
--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -1,6 +1,6 @@
 body {
     background-image: url('/static/images/kettlebell-bg.jpg');
-    background-size: cover;
-    background-position: center;
+    background-size: 300px;  /* smaller background image */
+    background-position: top right;
     background-repeat: no-repeat;
 }

--- a/app/templates/create_pass.html
+++ b/app/templates/create_pass.html
@@ -2,8 +2,10 @@
 <html lang="hu">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Új bérlet hozzáadása</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
 </head>
 <body class="bg-light">
     <div class="container mt-5">

--- a/app/templates/create_user.html
+++ b/app/templates/create_user.html
@@ -2,8 +2,10 @@
 <html lang="hu">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Felhasználó létrehozása</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
 </head>
 <body class="bg-light">
 <div class="container mt-5">

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -2,8 +2,10 @@
 <html lang="hu">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Dashboard</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
 </head>
 <body class="bg-light">
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark">

--- a/app/templates/extend_pass.html
+++ b/app/templates/extend_pass.html
@@ -2,8 +2,10 @@
 <html lang="hu">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Bérlet hosszabbítása</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
 </head>
 <body class="bg-light">
 <div class="container mt-5">

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -2,6 +2,7 @@
 <html lang="hu">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Bejelentkezés</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">

--- a/app/templates/users.html
+++ b/app/templates/users.html
@@ -2,8 +2,10 @@
 <html lang="hu">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Felhasználók</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
 </head>
 <body class="bg-light">
 <div class="container mt-5">

--- a/app/templates/verify_pass.html
+++ b/app/templates/verify_pass.html
@@ -2,8 +2,10 @@
 <html lang="hu">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Bérlet ellenőrzése</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
 </head>
 <body class="bg-light">
     <div class="container mt-5">


### PR DESCRIPTION
## Summary
- ensure pages have meta viewport for small-screen readability
- apply kettlebell background stylesheet across pages
- shrink background image so it doesn't overwhelm the UI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684946f71e94832a8f6f3f55e7d900cc