### PR TITLE
Limit kettlebell background to login view

### DIFF
--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -1,4 +1,4 @@
-body {
+.login-background {
     background-image: url('/static/images/kettlebell-bg.jpg');
     background-size: 300px;  /* smaller background image */
     background-position: top right;


### PR DESCRIPTION
## Summary
- keep kettlebell background only on the login page

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8 || true`

------
https://chatgpt.com/codex/tasks/task_e_6849483d5ad0832ab69ff57262e2ef08