### PR TITLE
Add email settings admin page

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -7,6 +7,7 @@ from wtforms import (
     SubmitField,
     SelectField,
     TextAreaField,
+    BooleanField,
 )
 from wtforms.validators import DataRequired, NumberRange
 
@@ -32,3 +33,25 @@ class LoginForm(FlaskForm):
     username = StringField('Felhasználónév', validators=[DataRequired()])
     password = PasswordField('Jelszó', validators=[DataRequired()])
     submit = SubmitField('Bejelentkezés')
+
+
+class EmailSettingsForm(FlaskForm):
+    email_from = StringField('Feladó email')
+    email_password = PasswordField('Email jelszó')
+
+    user_created_enabled = BooleanField('Felhasználó létrehozásakor')
+    user_created_text = TextAreaField('Létrehozás üzenete')
+
+    user_deleted_enabled = BooleanField('Felhasználó törlésekor')
+    user_deleted_text = TextAreaField('Törlés üzenete')
+
+    pass_created_enabled = BooleanField('Új bérlet létrehozásakor')
+    pass_created_text = TextAreaField('Bérlet létrehozás üzenete')
+
+    pass_deleted_enabled = BooleanField('Bérlet törlésekor')
+    pass_deleted_text = TextAreaField('Bérlet törlés üzenete')
+
+    pass_used_enabled = BooleanField('Alkalom változásakor')
+    pass_used_text = TextAreaField('Alkalom változás üzenete')
+
+    submit = SubmitField('Mentés')

--- a/app/models.py
+++ b/app/models.py
@@ -32,3 +32,25 @@ class Pass(db.Model):
 @login_manager.user_loader
 def load_user(user_id):
     return User.query.get(int(user_id))
+
+
+class EmailSettings(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    email_from = db.Column(db.String(150))
+    email_password = db.Column(db.String(150))
+
+    user_created_enabled = db.Column(db.Boolean, default=False)
+    user_created_text = db.Column(db.Text)
+
+    user_deleted_enabled = db.Column(db.Boolean, default=False)
+    user_deleted_text = db.Column(db.Text)
+
+    pass_created_enabled = db.Column(db.Boolean, default=False)
+    pass_created_text = db.Column(db.Text)
+
+    pass_deleted_enabled = db.Column(db.Boolean, default=False)
+    pass_deleted_text = db.Column(db.Text)
+
+    pass_used_enabled = db.Column(db.Boolean, default=False)
+    pass_used_text = db.Column(db.Text)
+

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -23,6 +23,7 @@
         <div class="mb-3">
             <a href="{{ url_for('admin.create_pass') }}" class="btn btn-success btn-sm">Új bérlet</a>
             <a href="{{ url_for('admin.users') }}" class="btn btn-primary btn-sm">Felhasználók</a>
+            <a href="{{ url_for('admin.email_settings') }}" class="btn btn-secondary btn-sm">Email beállítások</a>
         </div>
         {% endif %}
         <div class="row">

--- a/app/templates/email_settings.html
+++ b/app/templates/email_settings.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="hu">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Email beállítások</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
+</head>
+<body class="bg-light">
+<div class="container mt-5">
+    <h3>Email beállítások</h3>
+    <form method="post">
+        {{ form.hidden_tag() }}
+        <div class="mb-3">
+            {{ form.email_from.label(class="form-label") }}
+            {{ form.email_from(class="form-control") }}
+        </div>
+        <div class="mb-3">
+            {{ form.email_password.label(class="form-label") }}
+            {{ form.email_password(class="form-control") }}
+        </div>
+        <hr>
+        <div class="form-check">
+            {{ form.user_created_enabled(class="form-check-input") }}
+            {{ form.user_created_enabled.label(class="form-check-label") }}
+        </div>
+        <div class="mb-3">
+            {{ form.user_created_text.label(class="form-label") }}
+            {{ form.user_created_text(class="form-control") }}
+        </div>
+        <div class="form-check">
+            {{ form.user_deleted_enabled(class="form-check-input") }}
+            {{ form.user_deleted_enabled.label(class="form-check-label") }}
+        </div>
+        <div class="mb-3">
+            {{ form.user_deleted_text.label(class="form-label") }}
+            {{ form.user_deleted_text(class="form-control") }}
+        </div>
+        <div class="form-check">
+            {{ form.pass_created_enabled(class="form-check-input") }}
+            {{ form.pass_created_enabled.label(class="form-check-label") }}
+        </div>
+        <div class="mb-3">
+            {{ form.pass_created_text.label(class="form-label") }}
+            {{ form.pass_created_text(class="form-control") }}
+        </div>
+        <div class="form-check">
+            {{ form.pass_deleted_enabled(class="form-check-input") }}
+            {{ form.pass_deleted_enabled.label(class="form-check-label") }}
+        </div>
+        <div class="mb-3">
+            {{ form.pass_deleted_text.label(class="form-label") }}
+            {{ form.pass_deleted_text(class="form-control") }}
+        </div>
+        <div class="form-check">
+            {{ form.pass_used_enabled(class="form-check-input") }}
+            {{ form.pass_used_enabled.label(class="form-check-label") }}
+        </div>
+        <div class="mb-3">
+            {{ form.pass_used_text.label(class="form-label") }}
+            {{ form.pass_used_text(class="form-control") }}
+        </div>
+        {{ form.submit(class="btn btn-primary") }}
+        <a href="{{ url_for('user.dashboard') }}" class="btn btn-secondary">Vissza</a>
+    </form>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `EmailSettings` model to store email options
- add admin form and template for editing email notifications
- load credentials and message templates from the database when sending mail
- allow configuring when emails are sent via new admin page
- link email settings from the admin dashboard

## Testing
- `python -m py_compile app/forms.py app/models.py app/routes/admin_routes.py app/utils.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68494960c870832a95c2762f168c1d05