### PR TITLE
Fix user add/delete errors

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -9,7 +9,11 @@ class User(UserMixin, db.Model):
     email = db.Column(db.String(150), nullable=False, unique=True)
     password_hash = db.Column(db.String(256), nullable=False)
     role = db.Column(db.String(10), nullable=False, default='user')  # 'admin' or 'user'
-    passes = db.relationship('Pass', backref='user', lazy=True)
+    # Delete associated passes when a user is removed so foreign key
+    # constraints don't raise an ``IntegrityError``.
+    passes = db.relationship(
+        'Pass', backref='user', lazy=True, cascade='all, delete-orphan'
+    )
 
     def set_password(self, password):
         self.password_hash = generate_password_hash(password)


### PR DESCRIPTION
## Summary
- cascade delete passes when deleting a user
- guard against duplicate username or email when creating a user
- send user deletion email after capturing details

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68494e5656d4832ab5f26bcc9ace2c58