### PR TITLE
Enable admin password changes

### DIFF
--- a/app/templates/edit_user.html
+++ b/app/templates/edit_user.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="hu">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Felhasználó szerkesztése</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
+</head>
+<body class="bg-light">
+<div class="container mt-5">
+    <h3>Felhasználó szerkesztése</h3>
+    <form method="POST">
+        {{ form.hidden_tag() }}
+        <div class="mb-3">{{ form.username.label }} {{ form.username(class="form-control") }}</div>
+        <div class="mb-3">{{ form.email.label }} {{ form.email(class="form-control") }}</div>
+        <div class="mb-3">{{ form.password.label }} {{ form.password(class="form-control") }}</div>
+        <div class="mb-3">{{ form.role.label }} {{ form.role(class="form-select") }}</div>
+        <div class="mb-3">{{ form.submit(class="btn btn-primary") }}</div>
+    </form>
+</div>
+</body>
+</html>

--- a/app/templates/users.html
+++ b/app/templates/users.html
@@ -14,13 +14,16 @@
     <a href="{{ url_for('user.dashboard') }}" class="btn btn-secondary btn-sm mb-3">Visszalépés</a>
     <table class="table table-striped">
         <thead>
-            <tr><th>ID</th><th>Név</th><th>Email</th><th>Szerep</th><th></th></tr>
+            <tr><th>ID</th><th>Név</th><th>Email</th><th>Szerep</th><th>Műveletek</th></tr>
         </thead>
         <tbody>
         {% for u in users %}
             <tr>
                 <td>{{ u.id }}</td><td>{{ u.username }}</td><td>{{ u.email }}</td><td>{{ u.role }}</td>
-                <td><a href="{{ url_for('admin.delete_user', user_id=u.id) }}" class="btn btn-danger btn-sm">Törlés</a></td>
+                <td>
+                    <a href="{{ url_for('admin.edit_user', user_id=u.id) }}" class="btn btn-primary btn-sm">Szerkesztés</a>
+                    <a href="{{ url_for('admin.delete_user', user_id=u.id) }}" class="btn btn-danger btn-sm">Törlés</a>
+                </td>
             </tr>
         {% endfor %}
         </tbody>


### PR DESCRIPTION
## Summary
- add view and template to edit users including password updates
- list edit action on the user admin page
- show the new user edit form

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684951ccc734832a98419024de116084