### PR TITLE
Apply login background to pass cards

### DIFF
--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -4,3 +4,12 @@
     background-position: center;
     background-repeat: no-repeat;
 }
+
+.pass-card {
+    background-color: #000;
+    background-image: url('/static/images/kettlebell-bg.jpg');
+    background-size: auto 100%;
+    background-position: center;
+    background-repeat: no-repeat;
+    color: #fff;
+}

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -29,7 +29,7 @@
         <div class="row">
         {% for p in passes %}
             <div class="col-md-4 mb-3">
-                <div class="card h-100">
+                <div class="card h-100 pass-card">
                     <div class="card-body">
                         <h5 class="card-title">{{ p.type }}</h5>
                         <p class="card-text">{{ p.start_date }} - {{ p.end_date }}</p>

--- a/app/templates/verify_pass.html
+++ b/app/templates/verify_pass.html
@@ -9,7 +9,7 @@
 </head>
 <body class="bg-light">
     <div class="container mt-5">
-        <div class="card shadow">
+        <div class="card shadow pass-card">
             <div class="card-body">
                 <h4>Bérlet adatai</h4>
                 <p><strong>Típus:</strong> {{ p.type }}</p>


### PR DESCRIPTION
## Summary
- style pass cards with login page background image
- mark pass cards in templates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68495744d970832a9c2eca3508d256df