### PR TITLE
Match pass card size with admin view

### DIFF
--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -28,8 +28,8 @@
         {% endif %}
         <div class="row">
         {% for p in passes %}
-            <div class="col-md-4 mb-3">
-                <div class="card h-100 pass-card">
+            <div class="col-md-12 mb-3">
+                <div class="card shadow pass-card">
                     <div class="card-body">
                         <h5 class="card-title">{{ p.type }}</h5>
                         <p class="card-text">{{ p.start_date }} - {{ p.end_date }}</p>


### PR DESCRIPTION
## Summary
- show user pass cards at full width and use the same shadow style as admin

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684959320bcc832a911cf3f99d10d43d