### PR TITLE
Fix card widths

### DIFF
--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -28,7 +28,7 @@
         {% endif %}
         <div class="row">
         {% for p in passes %}
-            <div class="col-md-12 mb-3">
+            <div class="col-12 col-md-4 mb-3">
                 <div class="card shadow pass-card">
                     <div class="card-body">
                         <h5 class="card-title">{{ p.type }}</h5>

--- a/app/templates/verify_pass.html
+++ b/app/templates/verify_pass.html
@@ -9,8 +9,10 @@
 </head>
 <body class="bg-light">
     <div class="container mt-5">
-        <div class="card shadow pass-card">
-            <div class="card-body">
+        <div class="row justify-content-center">
+            <div class="col-12 col-md-4">
+                <div class="card shadow pass-card">
+                    <div class="card-body">
                 <h4>Bérlet adatai</h4>
                 <p><strong>Típus:</strong> {{ p.type }}</p>
                 <p><strong>Érvényesség:</strong> {{ p.start_date }} – {{ p.end_date }}</p>
@@ -30,5 +32,7 @@
             </div>
         </div>
     </div>
+</div>
+</div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- narrow dashboard cards to show three per row
- center verification card and shrink width

## Testing
- `python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_68495aa0e900832a8d03e487bd6b5483