### PR TITLE
Add backup and restore

### DIFF
--- a/app/templates/email_settings.html
+++ b/app/templates/email_settings.html
@@ -64,6 +64,10 @@
         {{ form.submit(class="btn btn-primary") }}
         <a href="{{ url_for('user.dashboard') }}" class="btn btn-secondary">Vissza</a>
     </form>
+    <div class="mt-3">
+        <a href="{{ url_for('admin.backup') }}" class="btn btn-danger">Backup</a>
+        <a href="{{ url_for('admin.restore') }}" class="btn btn-primary">Restore</a>
+    </div>
 </div>
 </body>
 </html>

--- a/app/templates/restore.html
+++ b/app/templates/restore.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="hu">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Adatbázis visszaállítása</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
+</head>
+<body class="bg-light">
+<div class="container mt-5">
+    <h3>Adatbázis visszaállítása</h3>
+    <form method="post" enctype="multipart/form-data">
+        {{ csrf_token() }}
+        <div class="mb-3">
+            <input type="file" name="backup_file" class="form-control" required>
+        </div>
+        <button type="submit" class="btn btn-primary">Visszaállítás</button>
+        <a href="{{ url_for('admin.email_settings') }}" class="btn btn-secondary">Mégse</a>
+    </form>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add backup/restore routes to admin blueprint
- add buttons on the email settings page
- add restore page for uploading a backup

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68497810b348832a9901de32385cd44e