### PR TITLE
Fix restore CSRF and show admin backup/restore buttons

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -8,6 +8,7 @@ from wtforms import (
     SelectField,
     TextAreaField,
     BooleanField,
+    FileField,
 )
 from wtforms.validators import DataRequired, NumberRange
 
@@ -55,3 +56,9 @@ class EmailSettingsForm(FlaskForm):
     pass_used_text = TextAreaField('Alkalom változás üzenete')
 
     submit = SubmitField('Mentés')
+
+
+class RestoreForm(FlaskForm):
+    """Form used for uploading a database backup to restore."""
+    backup_file = FileField('Backup fájl', validators=[DataRequired()])
+    submit = SubmitField('Visszaállítás')

--- a/app/routes/admin_routes.py
+++ b/app/routes/admin_routes.py
@@ -13,7 +13,7 @@ import os
 import shutil
 
 from ..models import Pass, User, db, EmailSettings
-from ..forms import PassForm, UserForm, EmailSettingsForm
+from ..forms import PassForm, UserForm, EmailSettingsForm, RestoreForm
 from ..utils import send_event_email
 from ..email_templates import (
     pass_created_email,
@@ -305,8 +305,9 @@ def restore():
     if current_user.role != 'admin':
         return redirect(url_for('user.dashboard'))
 
-    if request.method == 'POST':
-        uploaded = request.files.get('backup_file')
+    form = RestoreForm()
+    if form.validate_on_submit():
+        uploaded = form.backup_file.data
         if uploaded:
             instance_dir = os.path.abspath(os.path.join(current_app.root_path, '..', 'instance'))
             os.makedirs(instance_dir, exist_ok=True)
@@ -318,4 +319,4 @@ def restore():
             return redirect(url_for('admin.email_settings'))
         flash('Nem megfelelő fájl.', 'danger')
 
-    return render_template('restore.html')
+    return render_template('restore.html', form=form)

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -24,6 +24,8 @@
             <a href="{{ url_for('admin.create_pass') }}" class="btn btn-success btn-sm">Új bérlet</a>
             <a href="{{ url_for('admin.users') }}" class="btn btn-primary btn-sm">Felhasználók</a>
             <a href="{{ url_for('admin.email_settings') }}" class="btn btn-secondary btn-sm">Email beállítások</a>
+            <a href="{{ url_for('admin.backup') }}" class="btn btn-danger btn-sm">Backup</a>
+            <a href="{{ url_for('admin.restore') }}" class="btn btn-info btn-sm">Restore</a>
         </div>
         {% endif %}
         <div class="row">

--- a/app/templates/restore.html
+++ b/app/templates/restore.html
@@ -11,11 +11,11 @@
 <div class="container mt-5">
     <h3>Adatbázis visszaállítása</h3>
     <form method="post" enctype="multipart/form-data">
-        {{ csrf_token() }}
+        {{ form.hidden_tag() }}
         <div class="mb-3">
-            <input type="file" name="backup_file" class="form-control" required>
+            {{ form.backup_file(class="form-control") }}
         </div>
-        <button type="submit" class="btn btn-primary">Visszaállítás</button>
+        {{ form.submit(class="btn btn-primary") }}
         <a href="{{ url_for('admin.email_settings') }}" class="btn btn-secondary">Mégse</a>
     </form>
 </div>


### PR DESCRIPTION
## Summary
- support file upload with CSRF using a new `RestoreForm`
- show backup/restore links on the dashboard admin button row
- update restore route and template to use the form

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68497abb5018832abf67bbedf5fbc3a8