### PR TITLE
Prevent deleting admin user

### DIFF
--- a/app/routes/admin_routes.py
+++ b/app/routes/admin_routes.py
@@ -244,6 +244,10 @@ def delete_user(user_id):
         return redirect(url_for('user.dashboard'))
     user = User.query.get_or_404(user_id)
 
+    if user.username == 'admin':
+        flash('Az admin felhasználó nem törölhető.', 'danger')
+        return redirect(url_for('admin.users'))
+
     # Store details for the notification before the instance is removed
     username = user.username
     user_email = user.email

--- a/app/templates/users.html
+++ b/app/templates/users.html
@@ -22,7 +22,9 @@
                 <td>{{ u.id }}</td><td>{{ u.username }}</td><td>{{ u.email }}</td><td>{{ u.role }}</td>
                 <td>
                     <a href="{{ url_for('admin.edit_user', user_id=u.id) }}" class="btn btn-primary btn-sm">Szerkesztés</a>
+                    {% if u.username != 'admin' %}
                     <a href="{{ url_for('admin.delete_user', user_id=u.id) }}" class="btn btn-danger btn-sm">Törlés</a>
+                    {% endif %}
                 </td>
             </tr>
         {% endfor %}


### PR DESCRIPTION
## Summary
- protect admin user from deletion
- hide admin deletion button in UI

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68497c6a03fc832a830113a587d137de