### PR TITLE
Fix DB initialization to avoid 500 on forgot password

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -35,4 +35,10 @@ def create_app():
     app.register_blueprint(user_bp)
     app.register_blueprint(admin_bp)
 
+    # Ensure the database and required tables exist. Without this, a new
+    # deployment would raise ``OperationalError`` when a route queries a
+    # table that hasn't been created yet, resulting in a 500 error.
+    with app.app_context():
+        db.create_all()
+
     return app


### PR DESCRIPTION
## Summary
- ensure tables exist when the Flask app starts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849af6ed4a8832ab39504c81e2f75fb