### PR TITLE
Move pass usage list below subscription cards

### DIFF
--- a/app/routes/admin_routes.py
+++ b/app/routes/admin_routes.py
@@ -86,7 +86,7 @@ def extend_pass(pass_id):
         flash("Bérlet módosítva.", "success")
         return redirect(url_for('admin.verify_pass', pass_id=p.id))
 
-    return render_template('extend_pass.html', form=form, pass_id=pass_id)
+    return render_template('extend_pass.html', form=form, pass_id=pass_id, p=p)
 
 @admin_bp.route('/delete_pass/<int:pass_id>')
 @login_required

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -40,19 +40,21 @@
                         <p class="card-text">Felhasználó: {{ p.user.username }}</p>
                         {% endif %}
                         {% if p.comment %}<p class="card-text"><small>{{ p.comment }}</small></p>{% endif %}
-                        {% if p.usages %}
-                            <ul class="list-unstyled mb-2">
-                            {% for usage in p.usages %}
-                                <li><small>{{ usage.used_on.date() }}</small></li>
-                            {% endfor %}
-                            </ul>
-                        {% endif %}
                         {% if user.role == 'admin' %}
                             <a href="{{ url_for('admin.verify_pass', pass_id=p.id) }}" class="btn btn-sm btn-warning">Szerkesztés</a>
                             <a href="{{ url_for('admin.delete_pass', pass_id=p.id) }}" class="btn btn-sm btn-danger">Törlés</a>
                         {% endif %}
                     </div>
                 </div>
+                {% if user.role != 'admin' and p.usages %}
+                <div class="mt-2">
+                    <ul class="list-unstyled mb-2">
+                    {% for usage in p.usages %}
+                        <li><small>{{ usage.used_on.date() }}</small></li>
+                    {% endfor %}
+                    </ul>
+                </div>
+                {% endif %}
             </div>
         {% endfor %}
         </div>

--- a/app/templates/extend_pass.html
+++ b/app/templates/extend_pass.html
@@ -21,6 +21,16 @@
         <div class="mb-3">{{ form.submit(class="btn btn-primary") }}</div>
         <a href="{{ url_for('admin.verify_pass', pass_id=pass_id) }}" class="btn btn-secondary">Visszalépés</a>
     </form>
+    {% if p.usages %}
+    <div class="mt-3">
+        <h5>Felhasználások</h5>
+        <ul class="list-group list-group-flush">
+        {% for usage in p.usages %}
+            <li class="list-group-item bg-transparent text-white p-1">{{ usage.used_on.date() }}</li>
+        {% endfor %}
+        </ul>
+    </div>
+    {% endif %}
 </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- move pass usage history below each pass card
- hide usage history from admin dashboard
- show usage history when editing a pass

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c5a5bd6e4832ab29b9ee44d2f56c6