### PR TITLE
Update admin usage list location

### DIFF
--- a/app/templates/extend_pass.html
+++ b/app/templates/extend_pass.html
@@ -23,7 +23,7 @@
     </form>
     {% if p.usages %}
     <div class="mt-3">
-        <h5>Felhasználások</h5>
+        <h5>Felhasználva:</h5>
         <ul class="list-group list-group-flush">
         {% for usage in p.usages %}
             <li class="list-group-item bg-transparent text-white p-1">{{ usage.used_on.date() }}</li>

--- a/app/templates/verify_pass.html
+++ b/app/templates/verify_pass.html
@@ -19,16 +19,6 @@
                 <p><strong>Felhasznált alkalmak:</strong> {{ p.used }} / {{ p.total_uses }}</p>
                 <p><strong>Felhasználó:</strong> {{ p.user.username }}</p>
                 {% if p.comment %}<p><strong>Megjegyzés:</strong> {{ p.comment }}</p>{% endif %}
-                {% if p.usages %}
-                    <h5 class="mt-3">Felhasználások</h5>
-                    <ul class="list-group list-group-flush">
-                    {% for usage in p.usages %}
-                        <li class="list-group-item bg-transparent text-white p-1">
-                            {{ usage.used_on.date() }}
-                        </li>
-                    {% endfor %}
-                    </ul>
-                {% endif %}
                 {% if p.end_date < today or p.used >= p.total_uses %}
                     <div class="alert alert-danger">❌ A bérlet lejárt vagy kimerült.</div>
                 {% else %}
@@ -41,6 +31,16 @@
                 </div>
             </div>
         </div>
+        {% if p.usages %}
+        <div class="col-12 col-md-4 mt-3">
+            <h5>Felhasználva:</h5>
+            <ul class="list-group list-group-flush">
+            {% for usage in p.usages %}
+                <li class="list-group-item bg-transparent text-white p-1">{{ usage.used_on.date() }}</li>
+            {% endfor %}
+            </ul>
+        </div>
+        {% endif %}
     </div>
 </div>
 </div>


### PR DESCRIPTION
## Summary
- move usage history list outside of admin verification card
- relabel history section as `Felhasználva:` on edit and verify pages

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684c5bf89fac832a9c5d43a0623bf242