### PR TITLE
Fix admin pass usage display

### DIFF
--- a/app/templates/extend_pass.html
+++ b/app/templates/extend_pass.html
@@ -26,7 +26,7 @@
         <h5>Felhasználva:</h5>
         <ul class="list-group list-group-flush">
         {% for usage in p.usages %}
-            <li class="list-group-item bg-transparent text-white p-1">{{ usage.used_on.date() }}</li>
+            <li class="list-group-item bg-transparent p-1">{{ usage.used_on.date() }}</li>
         {% endfor %}
         </ul>
     </div>

--- a/app/templates/verify_pass.html
+++ b/app/templates/verify_pass.html
@@ -36,7 +36,7 @@
             <h5>Felhasználva:</h5>
             <ul class="list-group list-group-flush">
             {% for usage in p.usages %}
-                <li class="list-group-item bg-transparent text-white p-1">{{ usage.used_on.date() }}</li>
+                <li class="list-group-item bg-transparent p-1">{{ usage.used_on.date() }}</li>
             {% endfor %}
             </ul>
         </div>


### PR DESCRIPTION
## Summary
- fix list item style so usage dates appear correctly on admin pages

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684c5d8907f8832aa20c9917ed662d86