### PR TITLE
Show usage heading on dashboard

### DIFF
--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -48,6 +48,7 @@
                 </div>
                 {% if user.role != 'admin' and p.usages %}
                 <div class="mt-2">
+                    <h6>Felhasználva:</h6>
                     <ul class="list-unstyled mb-2">
                     {% for usage in p.usages %}
                         <li><small>{{ usage.used_on.date() }}</small></li>


### PR DESCRIPTION
## Summary
- show `Felhasználva:` heading on dashboard usage list

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684c5ef0ef30832aa1443e303a79ae3d