### PR TITLE
Resolve login failure caused by duplicate SQLAlchemy backref

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -95,6 +95,11 @@ class EventRegistration(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     event_id = db.Column(db.Integer, db.ForeignKey('event.id'), nullable=False)
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
-    user = db.relationship('User')
+    # ``User.event_registrations`` already adds a backref named ``user``
+    # so defining another relationship with the same name causes a
+    # ``sqlalchemy.exc.ArgumentError`` during mapper configuration.  The
+    # backref automatically provides the ``user`` attribute on
+    # ``EventRegistration`` instances, so the explicit relationship here is
+    # unnecessary and leads to conflicts when the models are imported.
 
 


### PR DESCRIPTION
## Summary
- fix mapper conflict in `EventRegistration` model by removing duplicate `user` relationship

## Testing
- `python -m py_compile app/models.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c6a92ed8c832ab8f9d426e505d8c0