### PR TITLE
Implement two-week calendar view for events

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -3,7 +3,7 @@ from wtforms import (
     StringField,
     PasswordField,
     DateField,
-    DateTimeField,
+    TimeField,
     IntegerField,
     SubmitField,
     SelectField,
@@ -72,7 +72,8 @@ class RestoreForm(FlaskForm):
 
 class EventForm(FlaskForm):
     name = StringField('Esemény neve', validators=[DataRequired()])
-    start_time = DateTimeField('Kezdő időpont', validators=[DataRequired()])
-    end_time = DateTimeField('Vég időpont', validators=[DataRequired()])
+    date = DateField('Dátum', validators=[DataRequired()])
+    start_time = TimeField('Kezdő időpont', validators=[DataRequired()])
+    end_time = TimeField('Vég időpont', validators=[DataRequired()])
     capacity = IntegerField('Létszám', validators=[DataRequired(), NumberRange(min=1)])
     submit = SubmitField('Mentés')

--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -15,3 +15,9 @@
     font-size: 1.5rem;
     font-weight: bold;
 }
+
+.calendar-table td {
+    width: 100px;
+    height: 60px;
+    vertical-align: top;
+}

--- a/app/templates/create_event.html
+++ b/app/templates/create_event.html
@@ -13,8 +13,9 @@
         <form method="POST">
             {{ form.hidden_tag() }}
             <div class="mb-3">{{ form.name.label }} {{ form.name(class="form-control") }}</div>
-            <div class="mb-3">{{ form.start_time.label }} {{ form.start_time(class="form-control") }}</div>
-            <div class="mb-3">{{ form.end_time.label }} {{ form.end_time(class="form-control") }}</div>
+            <div class="mb-3">{{ form.date.label }} {{ form.date(class="form-control", type="date") }}</div>
+            <div class="mb-3">{{ form.start_time.label }} {{ form.start_time(class="form-control", type="time") }}</div>
+            <div class="mb-3">{{ form.end_time.label }} {{ form.end_time(class="form-control", type="time") }}</div>
             <div class="mb-3">{{ form.capacity.label }} {{ form.capacity(class="form-control") }}</div>
             <div class="mb-3">{{ form.submit(class="btn btn-primary") }}</div>
         </form>

--- a/app/templates/events.html
+++ b/app/templates/events.html
@@ -19,22 +19,38 @@
     </nav>
     <div class="container mt-4">
         <h3>Események ({{ start }} - {{ end }})</h3>
-        {% for e in events %}
-        <div class="card mb-3">
-            <div class="card-body">
-                <h5 class="card-title">{{ e.name }}</h5>
-                <p class="card-text">{{ e.start_time }} - {{ e.end_time }}</p>
-                <p class="card-text">Szabad hely: {{ e.spots_left }} / {{ e.capacity }}</p>
-                {% if registrations.get(e.id) %}
-                    <a href="{{ url_for('events.unregister', event_id=e.id) }}" class="btn btn-warning btn-sm">Lejelentkezés</a>
-                {% elif e.spots_left > 0 %}
-                    <a href="{{ url_for('events.signup', event_id=e.id) }}" class="btn btn-primary btn-sm">Jelentkezés</a>
-                {% else %}
-                    <span class="text-danger">Nincs szabad hely</span>
-                {% endif %}
-            </div>
-        </div>
-        {% endfor %}
+        <table class="table table-bordered calendar-table">
+            <thead>
+                <tr>
+                    <th>Óra</th>
+                    {% for day in days %}
+                        <th>{{ day.strftime('%m-%d') }}</th>
+                    {% endfor %}
+                </tr>
+            </thead>
+            <tbody>
+                {% for hour in range(24) %}
+                <tr>
+                    <th>{{ '%02d:00' % hour }}</th>
+                    {% for day in days %}
+                        {% set evs = events_map.get((loop.index0, hour), []) %}
+                        <td>
+                            {% for e in evs %}
+                                <div class="bg-primary text-white p-1 mb-1">
+                                    {{ e.name }}
+                                    {% if registrations.get(e.id) %}
+                                        <a href="{{ url_for('events.unregister', event_id=e.id) }}" class="text-white">Le</a>
+                                    {% elif e.spots_left > 0 %}
+                                        <a href="{{ url_for('events.signup', event_id=e.id) }}" class="text-white">Fel</a>
+                                    {% endif %}
+                                </div>
+                            {% endfor %}
+                        </td>
+                    {% endfor %}
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
     </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- change `EventForm` to use date & time fields
- show events in a two-week calendar grid
- use date and time inputs when creating events
- add simple table styling

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c6c3972f0832a9e12ce2f970b62c0