### PR TITLE
Update default port to avoid conflicts

### DIFF
--- a/run.py
+++ b/run.py
@@ -3,5 +3,7 @@ from app import create_app
 app = create_app()
 
 if __name__ == "__main__":
-    app.run(debug=True)
+    # Run the application on port 5001 instead of the default 5000.
+    # This avoids conflicts if port 5000 is already in use.
+    app.run(debug=True, port=5001)
 


### PR DESCRIPTION
## Summary
- run Flask app on port `5001` instead of the default `5000`

## Testing
- `pip install -r requirements.txt` *(fails: cannot connect to pypi)*

------
https://chatgpt.com/codex/tasks/task_e_684c6e50dd34832a8f3330f8870e6bf3