### PR TITLE
Enable admin event management

### DIFF
--- a/app/routes/event_routes.py
+++ b/app/routes/event_routes.py
@@ -125,3 +125,29 @@ def add_user(event_id):
         db.session.commit()
         flash('Felhasználó hozzáadva.', 'success')
     return redirect(url_for('events.admin_events'))
+
+
+@event_bp.route('/admin/events/remove_user/<int:event_id>/<int:user_id>', methods=['POST'])
+@login_required
+def remove_user(event_id, user_id):
+    """Remove a user's registration from an event."""
+    if current_user.role != 'admin':
+        return redirect(url_for('events.events'))
+    reg = EventRegistration.query.filter_by(event_id=event_id, user_id=user_id).first_or_404()
+    db.session.delete(reg)
+    db.session.commit()
+    flash('Felhasználó eltávolítva.', 'success')
+    return redirect(url_for('events.admin_events'))
+
+
+@event_bp.route('/admin/events/delete/<int:event_id>', methods=['POST'])
+@login_required
+def delete_event(event_id):
+    """Delete an entire event."""
+    if current_user.role != 'admin':
+        return redirect(url_for('events.events'))
+    event = Event.query.get_or_404(event_id)
+    db.session.delete(event)
+    db.session.commit()
+    flash('Esemény törölve.', 'success')
+    return redirect(url_for('events.admin_events'))

--- a/app/templates/admin_events.html
+++ b/app/templates/admin_events.html
@@ -28,18 +28,30 @@
                 <p class="card-text">Szabad hely: {{ e.spots_left }} / {{ e.capacity }}</p>
                 <p class="card-text"><strong>Jelentkezők:</strong>
                     {% for reg in e.registrations %}
-                        {{ reg.user.username }}{% if not loop.last %}, {% endif %}
+                        <span class="me-1">
+                            {{ reg.user.username }}
+                            <form method="post" action="{{ url_for('events.remove_user', event_id=e.id, user_id=reg.user.id) }}" class="d-inline">
+                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                <button type="submit" class="btn btn-sm btn-link text-danger p-0">×</button>
+                            </form>
+                        </span>
+                        {% if not loop.last %}, {% endif %}
                     {% else %}
                         nincs
                     {% endfor %}
                 </p>
-                <form method="post" action="{{ url_for('events.add_user', event_id=e.id) }}" class="d-flex">
+                <form method="post" action="{{ url_for('events.add_user', event_id=e.id) }}" class="d-flex mb-2">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                     <select name="user_id" class="form-select form-select-sm me-2">
                         {% for u in users %}
                         <option value="{{ u.id }}">{{ u.username }}</option>
                         {% endfor %}
                     </select>
                     <button class="btn btn-primary btn-sm" type="submit">Hozzáadás</button>
+                </form>
+                <form method="post" action="{{ url_for('events.delete_event', event_id=e.id) }}">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                    <button class="btn btn-danger btn-sm" type="submit">Esemény törlése</button>
                 </form>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- add CSRF tokens to admin add user form
- allow admin to remove users from an event
- allow admin to delete events
- update admin event template with remove and delete buttons

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c762185c0832a908fabc6cc3bca80