### PR TITLE
Add visual separator for event registrants

### DIFF
--- a/app/templates/admin_events.html
+++ b/app/templates/admin_events.html
@@ -28,14 +28,12 @@
                 <p class="card-text">Szabad hely: {{ e.spots_left }} / {{ e.capacity }}</p>
                 <p class="card-text"><strong>Jelentkezők:</strong>
                     {% for reg in e.registrations %}
-                        <span class="me-1">
-                            {{ reg.user.username }}
-                            <form method="post" action="{{ url_for('events.remove_user', event_id=e.id, user_id=reg.user.id) }}" class="d-inline">
+                        <span class="me-1 d-inline-flex align-items-center">| {{ reg.user.username }}
+                            <form method="post" action="{{ url_for('events.remove_user', event_id=e.id, user_id=reg.user.id) }}" class="d-inline ms-1">
                                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                                 <button type="submit" class="btn btn-sm btn-link text-danger p-0">Töröl</button>
                             </form>
                         </span>
-                        {% if not loop.last %}, {% endif %}
                     {% else %}
                         nincs
                     {% endfor %}


### PR DESCRIPTION
## Summary
- show a `|` prefix for each event registrant
- keep delete button on same line by using inline flex

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684c7e36e188832aa3d2d9a400307d3e