### PR TITLE
Show day name for events

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -90,6 +90,26 @@ class Event(db.Model):
     def spots_left(self) -> int:
         return self.capacity - len(self.registrations)
 
+    @property
+    def formatted_time(self) -> str:
+        """Return the event time formatted with the Hungarian day name."""
+        day_names = [
+            'Hétfő',
+            'Kedd',
+            'Szerda',
+            'Csütörtök',
+            'Péntek',
+            'Szombat',
+            'Vasárnap',
+        ]
+        start = self.start_time
+        end = self.end_time
+        return (
+            f"{start.strftime('%Y-%m-%d')} "
+            f"{day_names[start.weekday()]} "
+            f"{start.strftime('%H:%M')} - {end.strftime('%H:%M')}"
+        )
+
 
 class EventRegistration(db.Model):
     id = db.Column(db.Integer, primary_key=True)

--- a/app/templates/admin_events.html
+++ b/app/templates/admin_events.html
@@ -24,7 +24,7 @@
         <div class="card mb-3">
             <div class="card-body">
                 <h5 class="card-title">{{ e.name }}</h5>
-                <p class="card-text">{{ e.start_time }} - {{ e.end_time }}</p>
+                <p class="card-text">{{ e.formatted_time }}</p>
                 <p class="card-text">Szabad hely: {{ e.spots_left }} / {{ e.capacity }}</p>
                 <p class="card-text"><strong>Jelentkezők:</strong><br>
                     {% for reg in e.registrations %}


### PR DESCRIPTION
## Summary
- add Event.formatted_time property for Hungarian day name
- show formatted time in admin events page

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684c824df0c8832ab6910ceb197d38dd