### PR TITLE
Update calendar signup links

### DIFF
--- a/app/templates/events.html
+++ b/app/templates/events.html
@@ -39,9 +39,9 @@
                                 <div class="bg-primary text-white p-1 mb-1">
                                     {{ e.name }}
                                     {% if registrations.get(e.id) %}
-                                        <a href="{{ url_for('events.unregister', event_id=e.id) }}" class="text-white">Le</a>
+                                        <a href="{{ url_for('events.unregister', event_id=e.id) }}" class="text-white">Leiratkozom</a>
                                     {% elif e.spots_left > 0 %}
-                                        <a href="{{ url_for('events.signup', event_id=e.id) }}" class="text-white">Fel</a>
+                                        <a href="{{ url_for('events.signup', event_id=e.id) }}" class="text-white">Feliratkozom</a>
                                     {% endif %}
                                 </div>
                             {% endfor %}


### PR DESCRIPTION
## Summary
- update calendar actions in `events.html` so that signup and unregister links are named
  `Feliratkozom` and `Leiratkozom`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c88397a8c832a8a1321be8d1031e3