### PR TITLE
Add admin calendar button

### DIFF
--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -31,6 +31,7 @@
         <div class="mb-3">
             {% if user.role == 'admin' %}
             <a href="{{ url_for('events.admin_events') }}" class="btn btn-warning btn-sm">Időpontok</a>
+            <a href="{{ url_for('events.events') }}" class="btn btn-warning btn-sm ms-2">Naptár</a>
             {% else %}
             <a href="{{ url_for('events.events') }}" class="btn btn-warning btn-sm">Időpontok</a>
             {% endif %}


### PR DESCRIPTION
## Summary
- give admins a quick link to the calendar users see

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684c89c0e754832aac0b52a36d8a3b2e