### PR TITLE
Improve calendar event display

### DIFF
--- a/app/routes/event_routes.py
+++ b/app/routes/event_routes.py
@@ -28,8 +28,17 @@ def events():
     events_map = {}
     for e in events:
         day_idx = (e.start_time.date() - start).days
-        hour = e.start_time.hour
-        events_map.setdefault((day_idx, hour), []).append(e)
+        start_hour = e.start_time.hour
+        end_hour = e.end_time.hour
+        for hour in range(start_hour, end_hour + 1):
+            start_minute = e.start_time.minute if hour == start_hour else 0
+            end_minute = e.end_time.minute if hour == end_hour else 60
+            events_map.setdefault((day_idx, hour), []).append({
+                'event': e,
+                'start_minute': start_minute,
+                'end_minute': end_minute,
+                'is_first': hour == start_hour,
+            })
     registrations = {
         reg.event_id: reg
         for reg in EventRegistration.query.filter_by(user_id=current_user.id)

--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -20,4 +20,18 @@
     width: 100px;
     height: 60px;
     vertical-align: top;
+    position: relative;
+    padding: 0;
+}
+
+.calendar-event {
+    position: absolute;
+    left: 0;
+    right: 0;
+    background-color: #0d6efd;
+    color: #fff;
+    font-size: 0.75rem;
+    padding: 2px;
+    border-radius: 2px;
+    overflow: hidden;
 }

--- a/app/templates/events.html
+++ b/app/templates/events.html
@@ -23,8 +23,9 @@
             <thead>
                 <tr>
                     <th>Óra</th>
+                    {% set day_names = ['Hétfő', 'Kedd', 'Szerda', 'Csütörtök', 'Péntek', 'Szombat', 'Vasárnap'] %}
                     {% for day in days %}
-                        <th>{{ day.strftime('%m-%d') }}</th>
+                        <th>{{ day.strftime('%m-%d') }} {{ day_names[day.weekday()] }}</th>
                     {% endfor %}
                 </tr>
             </thead>
@@ -35,13 +36,17 @@
                     {% for day in days %}
                         {% set evs = events_map.get((loop.index0, hour), []) %}
                         <td>
-                            {% for e in evs %}
-                                <div class="bg-primary text-white p-1 mb-1">
-                                    {{ e.name }}
-                                    {% if registrations.get(e.id) %}
-                                        <a href="{{ url_for('events.unregister', event_id=e.id) }}" class="text-white">Leiratkozom</a>
-                                    {% elif e.spots_left > 0 %}
-                                        <a href="{{ url_for('events.signup', event_id=e.id) }}" class="text-white">Feliratkozom</a>
+                            {% for seg in evs %}
+                                {% set e = seg.event %}
+                                <div class="calendar-event{% if seg.is_first %} with-text{% endif %}"
+                                     style="top: {{ seg.start_minute }}px; height: {{ seg.end_minute - seg.start_minute }}px;">
+                                    {% if seg.is_first %}
+                                        {{ e.name }}
+                                        {% if registrations.get(e.id) %}
+                                            <a href="{{ url_for('events.unregister', event_id=e.id) }}" class="text-white">Leiratkozom</a>
+                                        {% elif e.spots_left > 0 %}
+                                            <a href="{{ url_for('events.signup', event_id=e.id) }}" class="text-white">Feliratkozom</a>
+                                        {% endif %}
                                     {% endif %}
                                 </div>
                             {% endfor %}


### PR DESCRIPTION
## Summary
- render day names beside dates in calendar
- display events with quarter-hour resolution spanning hours
- style calendar events using CSS positioning

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_684c8c6c53fc832a849f78379a86bdf2