### PR TITLE
Fix event text clipping in calendar

### DIFF
--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -35,3 +35,8 @@
     border-radius: 2px;
     overflow: hidden;
 }
+
+.calendar-event.with-text {
+    overflow: visible;
+    z-index: 1;
+}


### PR DESCRIPTION
## Summary
- show full calendar entry text when events span multiple hours

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c8e5a2bec832aa19c77405ad316b5