### PR TITLE
Add calendar event color selection

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -76,4 +76,18 @@ class EventForm(FlaskForm):
     start_time = TimeField('Kezdő időpont', validators=[DataRequired()])
     end_time = TimeField('Vég időpont', validators=[DataRequired()])
     capacity = IntegerField('Létszám', validators=[DataRequired(), NumberRange(min=1)])
+    color = SelectField(
+        'Szín',
+        choices=[
+            ('darkgreen', 'Sötétzöld'),
+            ('red', 'Piros'),
+            ('blue', 'Kék'),
+            ('purple', 'Lila'),
+            ('orange', 'Narancs'),
+            ('burgundy', 'Bordó'),
+            ('darkblue', 'Sötétkék'),
+        ],
+        default='blue',
+        validators=[DataRequired()],
+    )
     submit = SubmitField('Mentés')

--- a/app/models.py
+++ b/app/models.py
@@ -82,9 +82,25 @@ class Event(db.Model):
     start_time = db.Column(db.DateTime, nullable=False)
     end_time = db.Column(db.DateTime, nullable=False)
     capacity = db.Column(db.Integer, nullable=False)
+    color = db.Column(db.String(20), nullable=False, default='blue')
     registrations = db.relationship(
         'EventRegistration', backref='event', lazy=True, cascade='all, delete-orphan'
     )
+
+    COLOR_MAP = {
+        'darkgreen': '#006400',
+        'red': '#dc3545',
+        'blue': '#0d6efd',
+        'purple': '#6f42c1',
+        'orange': '#fd7e14',
+        'burgundy': '#800020',
+        'darkblue': '#00008b',
+    }
+
+    @property
+    def color_hex(self) -> str:
+        """Return the hex color code for the event's color."""
+        return self.COLOR_MAP.get(self.color, '#0d6efd')
 
     @property
     def spots_left(self) -> int:

--- a/app/routes/event_routes.py
+++ b/app/routes/event_routes.py
@@ -109,6 +109,7 @@ def create_event():
             start_time=start_dt,
             end_time=end_dt,
             capacity=form.capacity.data,
+            color=form.color.data,
         )
         db.session.add(event)
         db.session.commit()

--- a/app/templates/create_event.html
+++ b/app/templates/create_event.html
@@ -17,6 +17,7 @@
             <div class="mb-3">{{ form.start_time.label }} {{ form.start_time(class="form-control", type="time") }}</div>
             <div class="mb-3">{{ form.end_time.label }} {{ form.end_time(class="form-control", type="time") }}</div>
             <div class="mb-3">{{ form.capacity.label }} {{ form.capacity(class="form-control") }}</div>
+            <div class="mb-3">{{ form.color.label }} {{ form.color(class="form-select") }}</div>
             <div class="mb-3">{{ form.submit(class="btn btn-primary") }}</div>
         </form>
     </div>

--- a/app/templates/events.html
+++ b/app/templates/events.html
@@ -39,7 +39,7 @@
                             {% for seg in evs %}
                                 {% set e = seg.event %}
                                 <div class="calendar-event{% if seg.is_first %} with-text{% endif %}"
-                                     style="top: {{ seg.start_minute }}px; height: {{ seg.end_minute - seg.start_minute }}px;">
+                                     style="top: {{ seg.start_minute }}px; height: {{ seg.end_minute - seg.start_minute }}px; background-color: {{ e.color_hex }};">
                                     {% if seg.is_first %}
                                         {{ e.name }}
                                         {% if registrations.get(e.id) %}


### PR DESCRIPTION
## Summary
- allow admins to choose a colour when creating events
- store chosen colour in the `Event` model
- show coloured events on the calendar

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d0674d4e0832aaa0e3a3ca15fe0a9