### PR TITLE
Add event participant popovers

### DIFF
--- a/app/routes/event_routes.py
+++ b/app/routes/event_routes.py
@@ -43,6 +43,12 @@ def events():
         reg.event_id: reg
         for reg in EventRegistration.query.filter_by(user_id=current_user.id)
     }
+
+    participants = {
+        e.id: "<br>".join(reg.user.username for reg in e.registrations) or "nincs"
+        for e in events
+    }
+
     return render_template(
         'events.html',
         events=events,
@@ -51,6 +57,7 @@ def events():
         registrations=registrations,
         days=days,
         events_map=events_map,
+        participants=participants,
     )
 
 

--- a/app/templates/events.html
+++ b/app/templates/events.html
@@ -39,7 +39,9 @@
                             {% for seg in evs %}
                                 {% set e = seg.event %}
                                 <div class="calendar-event{% if seg.is_first %} with-text{% endif %}"
-                                     style="top: {{ seg.start_minute }}px; height: {{ seg.end_minute - seg.start_minute }}px; background-color: {{ e.color_hex }};">
+                                     style="top: {{ seg.start_minute }}px; height: {{ seg.end_minute - seg.start_minute }}px; background-color: {{ e.color_hex }};"
+                                     data-bs-toggle="popover" data-bs-trigger="hover focus" data-bs-placement="top"
+                                     data-bs-html="true" data-bs-content="{{ participants.get(e.id) }}">
                                     {% if seg.is_first %}
                                         {{ e.name }}
                                         {% if registrations.get(e.id) %}
@@ -57,5 +59,11 @@
             </tbody>
         </table>
     </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script>
+        document.querySelectorAll('[data-bs-toggle="popover"]').forEach(function (el) {
+            new bootstrap.Popover(el);
+        });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- show registered users in a popover over calendar events
- enable Bootstrap popovers via script

## Testing
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_684d14b98294832ab56f7dc6db39417b