### PR TITLE
Maintain anchor after modifying event

### DIFF
--- a/app/routes/event_routes.py
+++ b/app/routes/event_routes.py
@@ -141,7 +141,7 @@ def add_user(event_id):
         db.session.add(reg)
         db.session.commit()
         flash('Felhasználó hozzáadva.', 'success')
-    return redirect(url_for('events.admin_events'))
+    return redirect(url_for('events.admin_events', _anchor=f'event-{event_id}'))
 
 
 @event_bp.route('/admin/events/remove_user/<int:event_id>/<int:user_id>', methods=['POST'])
@@ -154,7 +154,7 @@ def remove_user(event_id, user_id):
     db.session.delete(reg)
     db.session.commit()
     flash('Felhasználó eltávolítva.', 'success')
-    return redirect(url_for('events.admin_events'))
+    return redirect(url_for('events.admin_events', _anchor=f'event-{event_id}'))
 
 
 @event_bp.route('/admin/events/delete/<int:event_id>', methods=['POST'])
@@ -167,4 +167,4 @@ def delete_event(event_id):
     db.session.delete(event)
     db.session.commit()
     flash('Esemény törölve.', 'success')
-    return redirect(url_for('events.admin_events'))
+    return redirect(url_for('events.admin_events', _anchor=f'event-{event_id}'))

--- a/app/templates/admin_events.html
+++ b/app/templates/admin_events.html
@@ -21,7 +21,7 @@
         <h3>Események ({{ start }} - {{ end }})</h3>
         <a href="{{ url_for('events.create_event') }}" class="btn btn-success btn-sm mb-3">Új esemény</a>
         {% for e in events %}
-        <div class="card mb-3">
+        <div class="card mb-3" id="event-{{ e.id }}">
             <div class="card-body">
                 <h5 class="card-title">{{ e.name }}</h5>
                 <p class="card-text">{{ e.formatted_time }}</p>


### PR DESCRIPTION
## Summary
- keep focus on event after admin modifications

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684d16558744832a8a3b85f7f1cc6201