### PR TITLE
Implement color-coded calendar days

### DIFF
--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -40,3 +40,19 @@
     overflow: visible;
     z-index: 1;
 }
+
+/* Background colors for calendar columns */
+.calendar-table th.weekday,
+.calendar-table td.weekday {
+    background-color: #e9f4ff; /* light blue */
+}
+
+.calendar-table th.saturday,
+.calendar-table td.saturday {
+    background-color: #fff9e6; /* light yellow */
+}
+
+.calendar-table th.sunday,
+.calendar-table td.sunday {
+    background-color: #ffe6e6; /* light red */
+}

--- a/app/templates/events.html
+++ b/app/templates/events.html
@@ -25,7 +25,13 @@
                     <th>Óra</th>
                     {% set day_names = ['Hétfő', 'Kedd', 'Szerda', 'Csütörtök', 'Péntek', 'Szombat', 'Vasárnap'] %}
                     {% for day in days %}
-                        <th>{{ day.strftime('%m-%d') }} {{ day_names[day.weekday()] }}</th>
+                        {% set cls = 'weekday' %}
+                        {% if day.weekday() == 5 %}
+                            {% set cls = 'saturday' %}
+                        {% elif day.weekday() == 6 %}
+                            {% set cls = 'sunday' %}
+                        {% endif %}
+                        <th class="{{ cls }}">{{ day.strftime('%m-%d') }} {{ day_names[day.weekday()] }}</th>
                     {% endfor %}
                 </tr>
             </thead>
@@ -35,7 +41,13 @@
                     <th>{{ '%02d:00' % hour }}</th>
                     {% for day in days %}
                         {% set evs = events_map.get((loop.index0, hour), []) %}
-                        <td>
+                        {% set cls = 'weekday' %}
+                        {% if day.weekday() == 5 %}
+                            {% set cls = 'saturday' %}
+                        {% elif day.weekday() == 6 %}
+                            {% set cls = 'sunday' %}
+                        {% endif %}
+                        <td class="{{ cls }}">
                             {% for seg in evs %}
                                 {% set e = seg.event %}
                                 <div class="calendar-event{% if seg.is_first %} with-text{% endif %}"


### PR DESCRIPTION
## Summary
- add CSS classes to color calendar weekdays, Saturdays and Sundays
- apply new classes in events template for header and cells

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684d17a3b200832aa8d788b4e3e1c182