### PR TITLE
Add event edit page

### DIFF
--- a/app/templates/admin_events.html
+++ b/app/templates/admin_events.html
@@ -28,24 +28,12 @@
                 <p class="card-text">Szabad hely: {{ e.spots_left }} / {{ e.capacity }}</p>
                 <p class="card-text"><strong>Jelentkezők:</strong><br>
                     {% for reg in e.registrations %}
-                        <form method="post" action="{{ url_for('events.remove_user', event_id=e.id, user_id=reg.user.id) }}" class="d-inline-flex align-items-center me-2">
-                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                            <span class="me-1">|| {{ reg.user.username }}</span>
-                            <button type="submit" class="btn btn-sm btn-link text-danger p-0">Töröl</button>
-                        </form>
+                        {{ reg.user.username }}{% if not loop.last %}, {% endif %}
                     {% else %}
                         nincs
                     {% endfor %}
                 </p>
-                <form method="post" action="{{ url_for('events.add_user', event_id=e.id) }}" class="d-flex mb-2">
-                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                    <select name="user_id" class="form-select form-select-sm me-2">
-                        {% for u in users %}
-                        <option value="{{ u.id }}">{{ u.username }}</option>
-                        {% endfor %}
-                    </select>
-                    <button class="btn btn-primary btn-sm" type="submit">Hozzáadás</button>
-                </form>
+                <a href="{{ url_for('events.edit_event', event_id=e.id) }}" class="btn btn-secondary btn-sm mb-2">Szerkesztés</a>
                 <form method="post" action="{{ url_for('events.delete_event', event_id=e.id) }}">
                     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                     <button class="btn btn-danger btn-sm" type="submit">Esemény törlése</button>

--- a/app/templates/edit_event.html
+++ b/app/templates/edit_event.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="hu">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Esemény szerkesztése</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
+</head>
+<body class="bg-light">
+    <div class="container mt-5">
+        <h3>Esemény szerkesztése</h3>
+        <form method="POST">
+            {{ form.hidden_tag() }}
+            <div class="mb-3">
+                <label class="form-label">Név</label>
+                <input type="text" class="form-control" value="{{ event.name }}" disabled>
+            </div>
+            <div class="mb-3">{{ form.date.label }} {{ form.date(class="form-control", type="date") }}</div>
+            <div class="mb-3">{{ form.start_time.label }} {{ form.start_time(class="form-control", type="time") }}</div>
+            <div class="mb-3">{{ form.end_time.label }} {{ form.end_time(class="form-control", type="time") }}</div>
+            <div class="mb-3">{{ form.capacity.label }} {{ form.capacity(class="form-control") }}</div>
+            <div class="mb-3">{{ form.color.label }} {{ form.color(class="form-select") }}</div>
+            <div class="mb-3">{{ form.submit(class="btn btn-primary") }}</div>
+        </form>
+        <hr>
+        <h5>Jelentkezők</h5>
+        <p>
+            {% for reg in event.registrations %}
+                <form method="post" action="{{ url_for('events.remove_user', event_id=event.id, user_id=reg.user.id, next='edit') }}" class="d-inline-flex align-items-center me-2">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                    <span class="me-1">{{ reg.user.username }}</span>
+                    <button type="submit" class="btn btn-sm btn-link text-danger p-0">Töröl</button>
+                </form>
+            {% else %}
+                nincs
+            {% endfor %}
+        </p>
+        <form method="post" action="{{ url_for('events.add_user', event_id=event.id, next='edit') }}" class="d-flex mb-2">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <select name="user_id" class="form-select form-select-sm me-2">
+                {% for u in users %}
+                <option value="{{ u.id }}">{{ u.username }}</option>
+                {% endfor %}
+            </select>
+            <button class="btn btn-primary btn-sm" type="submit">Hozzáadás</button>
+        </form>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add edit page for events with forms for adjusting time, capacity, color and managing participants
- link from admin events listing via new 'Szerkesztés' button
- adjust add/remove participant logic to return to edit page when appropriate

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684d1b7565fc832aa8133f7bc95ecb78