### PR TITLE
Add back link from edit event page

### DIFF
--- a/app/templates/edit_event.html
+++ b/app/templates/edit_event.html
@@ -10,6 +10,7 @@
 <body class="bg-light">
     <div class="container mt-5">
         <h3>Esemény szerkesztése</h3>
+        <a href="{{ url_for('events.admin_events') }}" class="btn btn-secondary btn-sm mb-3">Vissza az eseményekhez</a>
         <form method="POST">
             {{ form.hidden_tag() }}
             <div class="mb-3">


### PR DESCRIPTION
## Summary
- let admins return to events listing from event edit page

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d1d442e30832aa7070a3bbba809d3