### PR TITLE
Improve admin event cards

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -126,6 +126,16 @@ class Event(db.Model):
             f"{start.strftime('%H:%M')} - {end.strftime('%H:%M')}"
         )
 
+    @property
+    def status(self) -> str:
+        """Return whether the event is past, ongoing or upcoming."""
+        now = datetime.now()
+        if self.end_time < now:
+            return "past"
+        if self.start_time <= now <= self.end_time:
+            return "ongoing"
+        return "upcoming"
+
 
 class EventRegistration(db.Model):
     id = db.Column(db.Integer, primary_key=True)

--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -41,6 +41,17 @@
     z-index: 1;
 }
 
+/* Colors for admin event cards based on status */
+.event-card.past {
+    background-color: #f8d7da;
+}
+.event-card.ongoing {
+    background-color: #fff3cd;
+}
+.event-card.upcoming {
+    background-color: #d1e7dd;
+}
+
 /* Background colors for calendar columns */
 .calendar-table th.weekday,
 .calendar-table td.weekday {

--- a/app/templates/admin_events.html
+++ b/app/templates/admin_events.html
@@ -20,27 +20,31 @@
     <div class="container mt-4">
         <h3>Események ({{ start }} - {{ end }})</h3>
         <a href="{{ url_for('events.create_event') }}" class="btn btn-success btn-sm mb-3">Új esemény</a>
+        <div class="row">
         {% for e in events %}
-        <div class="card mb-3" id="event-{{ e.id }}">
-            <div class="card-body">
-                <h5 class="card-title">{{ e.name }}</h5>
-                <p class="card-text">{{ e.formatted_time }}</p>
-                <p class="card-text">Szabad hely: {{ e.spots_left }} / {{ e.capacity }}</p>
-                <p class="card-text"><strong>Jelentkezők:</strong><br>
-                    {% for reg in e.registrations %}
-                        {{ reg.user.username }}{% if not loop.last %}, {% endif %}
-                    {% else %}
-                        nincs
-                    {% endfor %}
-                </p>
-                <a href="{{ url_for('events.edit_event', event_id=e.id) }}" class="btn btn-secondary btn-sm mb-2">Szerkesztés</a>
-                <form method="post" action="{{ url_for('events.delete_event', event_id=e.id) }}">
-                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                    <button class="btn btn-danger btn-sm" type="submit">Esemény törlése</button>
-                </form>
+            <div class="col-12 col-md-6">
+                <div class="card mb-3 event-card {{ e.status }}" id="event-{{ e.id }}">
+                    <div class="card-body">
+                        <h5 class="card-title">{{ e.name }}</h5>
+                        <p class="card-text">{{ e.formatted_time }}</p>
+                        <p class="card-text">Szabad hely: {{ e.spots_left }} / {{ e.capacity }}</p>
+                        <p class="card-text"><strong>Jelentkezők:</strong><br>
+                            {% for reg in e.registrations %}
+                                {{ reg.user.username }}{% if not loop.last %}, {% endif %}
+                            {% else %}
+                                nincs
+                            {% endfor %}
+                        </p>
+                        <a href="{{ url_for('events.edit_event', event_id=e.id) }}" class="btn btn-secondary btn-sm mb-2">Szerkesztés</a>
+                        <form method="post" action="{{ url_for('events.delete_event', event_id=e.id) }}">
+                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                            <button class="btn btn-danger btn-sm" type="submit">Esemény törlése</button>
+                        </form>
+                    </div>
+                </div>
             </div>
-        </div>
         {% endfor %}
+        </div>
     </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- display admin events in a responsive two-column layout
- colour code events based on time (past, ongoing, upcoming)
- expose `Event.status` helper property for templates

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684d1f16eb38832ab202e1c951b83b38