### PR TITLE
Fix undo pass email

### DIFF
--- a/app/email_templates.py
+++ b/app/email_templates.py
@@ -55,6 +55,18 @@ def pass_used_email(p) -> str:
     return base_email_template("Bérlet használat", content)
 
 
+def pass_usage_reverted_email(p) -> str:
+    """Return the email HTML when a pass usage is undone."""
+    remaining = p.total_uses - p.used
+    content = (
+        f"Kedves {p.user.username},<br>"
+        f"Visszakaptál egy alkalmat a(z) {p.type} bérletedbe.<br>"
+        f"Hátralévő alkalmak: {remaining}.<br><br>"
+        f"{_pass_details(p)}"
+    )
+    return base_email_template("Bérlethasználat visszavonva", content)
+
+
 def _event_details(e) -> str:
     """Return a HTML snippet describing an ``Event``."""
     return (

--- a/app/routes/admin_routes.py
+++ b/app/routes/admin_routes.py
@@ -19,6 +19,7 @@ from ..email_templates import (
     pass_created_email,
     pass_deleted_email,
     pass_used_email,
+    pass_usage_reverted_email,
     registration_email,
     base_email_template,
 )
@@ -170,8 +171,8 @@ def undo_use(pass_id):
         db.session.commit()
         send_event_email(
             'pass_used',
-            "Bérlet használat",
-            pass_used_email(p),
+            "Bérlet használat visszavonva",
+            pass_usage_reverted_email(p),
             p.user.email,
         )
         flash("Felhasználás visszavonva.", "success")


### PR DESCRIPTION
## Summary
- send a different email when pass usage is undone
- add new template for reverted usage emails

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d26dcaf44832a8740aba0b96f374e