### PR TITLE
Add dynamic update for weekly reminder schedule

### DIFF
--- a/app/routes/admin_routes.py
+++ b/app/routes/admin_routes.py
@@ -15,6 +15,7 @@ import shutil
 from ..models import Pass, PassUsage, User, db, EmailSettings
 from ..forms import PassForm, UserForm, EmailSettingsForm, RestoreForm
 from ..utils import send_event_email
+from .. import update_weekly_reminder_schedule
 from ..email_templates import (
     pass_created_email,
     pass_deleted_email,
@@ -296,6 +297,7 @@ def email_settings():
     if form.validate_on_submit():
         form.populate_obj(settings)
         db.session.commit()
+        update_weekly_reminder_schedule(current_app)
         flash("Beállítások mentve.", "success")
         return redirect(url_for('user.dashboard'))
 


### PR DESCRIPTION
## Summary
- allow rescheduling weekly reminder emails when email settings are saved
- create shared scheduler and helper function to update schedule
- hook schedule update into admin email settings route

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68720a568dac832aa37a33030285e878