### PR TITLE
Fix weekly email schedule timezone

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -5,6 +5,7 @@ from flask_wtf import CSRFProtect
 import os
 from dotenv import load_dotenv
 import logging
+from zoneinfo import ZoneInfo
 
 try:
     from apscheduler.schedulers.background import BackgroundScheduler
@@ -25,7 +26,11 @@ load_dotenv()
 db = SQLAlchemy()
 login_manager = LoginManager()
 csrf = CSRFProtect()
-scheduler = BackgroundScheduler() if BackgroundScheduler else None
+scheduler = (
+    BackgroundScheduler(timezone=ZoneInfo("Europe/Budapest"))
+    if BackgroundScheduler
+    else None
+)
 
 def update_weekly_reminder_schedule(app):
     """Configure the weekly reminder job based on current settings."""


### PR DESCRIPTION
## Summary
- set APScheduler timezone to Europe/Budapest so weekly reminders trigger correctly

## Testing
- `python3 -m py_compile app/__init__.py`
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68722ed30078832aadf46550a5d46075