### PR TITLE
Fix weekly reminder timezone

### DIFF
--- a/send_weekly_reminders.py
+++ b/send_weekly_reminders.py
@@ -1,4 +1,5 @@
-from datetime import date
+from datetime import datetime
+from zoneinfo import ZoneInfo
 
 from app import create_app
 from app.models import EmailSettings
@@ -11,6 +12,7 @@ with app.app_context():
     if (
         settings
         and settings.weekly_reminder_enabled
-        and settings.weekly_reminder_day == date.today().weekday()
+        and settings.weekly_reminder_day
+        == datetime.now(ZoneInfo("Europe/Budapest")).weekday()
     ):
         send_weekly_reminders(app)


### PR DESCRIPTION
## Summary
- use Europe/Budapest timezone in `send_weekly_reminders.py`

## Testing
- `python -m py_compile send_weekly_reminders.py`
- `pytest -q`
- `black --check $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6884dbb5b5ec832aa8cb4402daf2aead