### PR TITLE
Implement self-service registration and event management upgrades

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -1,4 +1,5 @@
 from flask_wtf import FlaskForm
+from flask_wtf.file import FileAllowed
 from wtforms import (
     StringField,
     PasswordField,
@@ -10,8 +11,17 @@ from wtforms import (
     TextAreaField,
     BooleanField,
     FileField,
+    DecimalField,
+    RadioField,
 )
-from wtforms.validators import DataRequired, NumberRange
+from wtforms.validators import (
+    DataRequired,
+    NumberRange,
+    Email,
+    Length,
+    EqualTo,
+    Optional,
+)
 
 class PassForm(FlaskForm):
     type = StringField('Típus', validators=[DataRequired()])
@@ -38,8 +48,19 @@ class LoginForm(FlaskForm):
 
 
 class ForgotPasswordForm(FlaskForm):
-    email = StringField('Email', validators=[DataRequired()])
+    email = StringField('Email', validators=[DataRequired(), Email()])
     submit = SubmitField('Jelszó elküldése')
+
+
+class RegistrationForm(FlaskForm):
+    username = StringField('Felhasználónév', validators=[DataRequired(), Length(min=3, max=150)])
+    email = StringField('Email', validators=[DataRequired(), Email()])
+    password = PasswordField('Jelszó', validators=[DataRequired(), Length(min=6)])
+    confirm_password = PasswordField(
+        'Jelszó megerősítése',
+        validators=[DataRequired(), EqualTo('password', message='A jelszavak nem egyeznek.')],
+    )
+    submit = SubmitField('Regisztráció')
 
 
 class EmailSettingsForm(FlaskForm):
@@ -105,6 +126,7 @@ class EventForm(FlaskForm):
     start_time = TimeField('Kezdő időpont', validators=[DataRequired()])
     end_time = TimeField('Vég időpont', validators=[DataRequired()])
     capacity = IntegerField('Létszám', validators=[DataRequired(), NumberRange(min=1)])
+    price = DecimalField('Ár (HUF)', places=2, rounding=None, validators=[Optional(), NumberRange(min=0)])
     color = SelectField(
         'Szín',
         choices=[
@@ -119,4 +141,15 @@ class EventForm(FlaskForm):
         default='blue',
         validators=[DataRequired()],
     )
+    image = FileField('Kép feltöltése', validators=[FileAllowed(['jpg', 'jpeg', 'png', 'gif'], 'Csak kép tölthető fel.')])
     submit = SubmitField('Mentés')
+
+
+class PurchasePassForm(FlaskForm):
+    pass_type = RadioField(
+        'Bérlet típusa',
+        choices=[('4', '4 alkalmas'), ('8', '8 alkalmas')],
+        default='4',
+        validators=[DataRequired()],
+    )
+    submit = SubmitField('Bérlet vásárlása')

--- a/app/routes/auth_routes.py
+++ b/app/routes/auth_routes.py
@@ -1,17 +1,19 @@
 from flask import Blueprint, render_template, redirect, url_for, flash, request
-from flask_login import login_user, logout_user, login_required
-from ..models import User
+from flask_login import login_user, logout_user, login_required, current_user
 from werkzeug.security import check_password_hash
-from ..forms import LoginForm, ForgotPasswordForm
+
+from ..models import User, db
+from ..forms import LoginForm, ForgotPasswordForm, RegistrationForm
 from ..utils import send_email
 from ..email_templates import forgot_password_email
-from .. import db
 import secrets
 
 auth_bp = Blueprint('auth', __name__)
 
 @auth_bp.route('/login', methods=['GET', 'POST'])
 def login():
+    if current_user.is_authenticated:
+        return redirect(url_for('user.dashboard'))
     form = LoginForm()
     if form.validate_on_submit():
         username = form.username.data
@@ -21,8 +23,33 @@ def login():
         if user and check_password_hash(user.password_hash, password):
             login_user(user)
             return redirect(url_for('user.dashboard'))
-        flash('Hibás felhasználónév vagy jelszó.')
+        flash('Hibás felhasználónév vagy jelszó.', 'danger')
     return render_template('login.html', form=form)
+
+
+@auth_bp.route('/register', methods=['GET', 'POST'])
+def register():
+    if current_user.is_authenticated:
+        return redirect(url_for('user.dashboard'))
+
+    form = RegistrationForm()
+    if form.validate_on_submit():
+        if User.query.filter_by(email=form.email.data).first():
+            flash('Az email cím már használatban van.', 'danger')
+            return render_template('register.html', form=form)
+        if User.query.filter_by(username=form.username.data).first():
+            flash('A felhasználónév már foglalt.', 'danger')
+            return render_template('register.html', form=form)
+
+        user = User(username=form.username.data, email=form.email.data)
+        user.set_password(form.password.data)
+        user.role = 'user'
+        db.session.add(user)
+        db.session.commit()
+        login_user(user)
+        flash('Sikeres regisztráció. Üdvözlünk!', 'success')
+        return redirect(url_for('user.dashboard'))
+    return render_template('register.html', form=form)
 
 
 @auth_bp.route('/forgot_password', methods=['GET', 'POST'])

--- a/app/routes/event_routes.py
+++ b/app/routes/event_routes.py
@@ -1,8 +1,27 @@
-from flask import Blueprint, render_template, redirect, url_for, request, flash
-from flask_login import login_required, current_user
-from datetime import datetime, timedelta
+import os
+from datetime import datetime, timedelta, date
 
-from ..models import Event, EventRegistration, User, db
+from flask import (
+    Blueprint,
+    render_template,
+    redirect,
+    url_for,
+    request,
+    flash,
+    current_app,
+)
+from flask_login import login_required, current_user
+from werkzeug.utils import secure_filename
+
+from ..models import (
+    Event,
+    EventRegistration,
+    EventWaitlist,
+    User,
+    Pass,
+    PassUsage,
+    db,
+)
 from ..forms import EventForm
 from ..utils import send_event_email
 from ..email_templates import (
@@ -16,94 +35,316 @@ from ..email_templates import (
 event_bp = Blueprint('events', __name__)
 
 
-def _get_two_week_range():
-    start = datetime.now().date()
-    end = start + timedelta(days=13)
-    return start, end
+def _get_available_pass(user, preferred_pass_id=None):
+    """Return the user's first valid pass with remaining uses."""
+    today = date.today()
+    passes = Pass.query.filter_by(user_id=user.id).all()
+    valid = [
+        p
+        for p in passes
+        if p.start_date <= today <= p.end_date and p.used < p.total_uses
+    ]
+    if preferred_pass_id:
+        for p in valid:
+            if p.id == preferred_pass_id:
+                return p
+    if valid:
+        valid.sort(key=lambda p: (p.end_date, p.id))
+        return valid[0]
+    return None
+
+
+def _handle_pass_usage(selected_pass):
+    """Reserve one usage on the given pass and return the usage ID."""
+    selected_pass.used += 1
+    usage = PassUsage(pass_id=selected_pass.id)
+    db.session.add(usage)
+    db.session.flush()
+    return usage.id
+
+
+def _uploads_dir() -> str:
+    return os.path.join(current_app.root_path, 'static', 'uploads')
+
+
+def _save_event_image(file_storage):
+    if not file_storage or not file_storage.filename:
+        return None
+    filename = secure_filename(file_storage.filename)
+    if not filename:
+        return None
+    upload_dir = _uploads_dir()
+    os.makedirs(upload_dir, exist_ok=True)
+    timestamp = datetime.utcnow().strftime('%Y%m%d%H%M%S')
+    name, ext = os.path.splitext(filename)
+    final_name = f"{name}_{timestamp}{ext}"
+    path = os.path.join(upload_dir, final_name)
+    file_storage.save(path)
+    return os.path.join('uploads', final_name)
+
+
+def _cancel_registration(registration, force_late=None):
+    """Cancel a registration and handle pass adjustments."""
+    event = registration.event
+    now = datetime.now()
+    late_cancel = (
+        force_late
+        if force_late is not None
+        else (event.start_time - now <= timedelta(hours=48))
+    )
+    if registration.registration_type == 'pass' and registration.pass_id:
+        selected_pass = Pass.query.get(registration.pass_id)
+        if not late_cancel:
+            if selected_pass and selected_pass.used > 0:
+                selected_pass.used -= 1
+            if registration.pass_usage_id:
+                usage = PassUsage.query.get(registration.pass_usage_id)
+                if usage:
+                    db.session.delete(usage)
+            registration.pass_usage_id = None
+        else:
+            registration.is_late_cancel = True
+    registration.status = 'late_cancelled' if late_cancel else 'cancelled'
+    registration.cancelled_at = datetime.utcnow()
+    db.session.commit()
+    return late_cancel
+
+
+def _promote_waitlist_entry(entry, event=None, remove_on_fail=False):
+    """Promote a single waitlist entry to an active registration."""
+    event = event or entry.event
+    if not event or event.spots_left <= 0:
+        return False
+
+    if EventRegistration.query.filter_by(
+        event_id=event.id, user_id=entry.user_id, status='active'
+    ).first():
+        if remove_on_fail:
+            db.session.delete(entry)
+            db.session.commit()
+        return False
+
+    user = entry.user
+    selected_pass = None
+    if entry.registration_type == 'pass':
+        selected_pass = _get_available_pass(user, entry.pass_id)
+        if not selected_pass:
+            if remove_on_fail:
+                db.session.delete(entry)
+                db.session.commit()
+            return False
+
+    registration = EventRegistration(
+        event_id=event.id,
+        user_id=user.id,
+        registration_type=entry.registration_type,
+        waitlist_promoted=True,
+    )
+    if selected_pass:
+        registration.pass_id = selected_pass.id
+        registration.pass_usage_id = _handle_pass_usage(selected_pass)
+    db.session.add(registration)
+    db.session.delete(entry)
+    db.session.commit()
+
+    send_event_email(
+        'event_signup_user',
+        'Esemény jelentkezés',
+        event_signup_user_email(user.username, event),
+        user.email,
+    )
+    return True
+
+
+def _promote_waitlist(event_id: int):
+    """Move the first waitlisted users into the event if space allows."""
+    event = Event.query.get(event_id)
+    if not event:
+        return
+
+    while event.spots_left > 0:
+        entry = (
+            EventWaitlist.query.filter_by(event_id=event.id)
+            .order_by(EventWaitlist.created_at)
+            .first()
+        )
+        if not entry:
+            break
+        _promote_waitlist_entry(entry, event, remove_on_fail=True)
+        event = Event.query.get(event.id)
 
 
 @event_bp.route('/events')
 @login_required
 def events():
-    start, end = _get_two_week_range()
-    events = (
-        Event.query.filter(Event.start_time >= start, Event.start_time <= end)
-        .order_by(Event.start_time)
-        .all()
-    )
-    days = [start + timedelta(days=i) for i in range(14)]
-    events_map = {}
-    for e in events:
-        day_idx = (e.start_time.date() - start).days
-        start_hour = e.start_time.hour
-        end_hour = e.end_time.hour
-        for hour in range(start_hour, end_hour + 1):
-            start_minute = e.start_time.minute if hour == start_hour else 0
-            end_minute = e.end_time.minute if hour == end_hour else 60
-            events_map.setdefault((day_idx, hour), []).append({
-                'event': e,
-                'start_minute': start_minute,
-                'end_minute': end_minute,
-                'is_first': hour == start_hour,
-            })
-    registrations = {
+    events = Event.query.order_by(Event.start_time).all()
+    active_registrations = {
         reg.event_id: reg
-        for reg in EventRegistration.query.filter_by(user_id=current_user.id)
+        for reg in EventRegistration.query.filter_by(
+            user_id=current_user.id, status='active'
+        )
     }
-
-    participants = {
-        e.id: "<br>".join(reg.user.username for reg in e.registrations) or "nincs"
-        for e in events
+    latest_registrations = {}
+    for reg in (
+        EventRegistration.query.filter_by(user_id=current_user.id)
+        .order_by(EventRegistration.created_at.desc())
+        .all()
+    ):
+        if reg.event_id not in latest_registrations:
+            latest_registrations[reg.event_id] = reg
+    waitlist_map = {
+        entry.event_id: entry
+        for entry in EventWaitlist.query.filter_by(user_id=current_user.id).all()
     }
-
+    has_active_pass = _get_available_pass(current_user) is not None
     return render_template(
         'events.html',
         events=events,
-        start=start,
-        end=end,
-        registrations=registrations,
-        days=days,
-        events_map=events_map,
-        participants=participants,
+        active_registrations=active_registrations,
+        latest_registrations=latest_registrations,
+        waitlist_map=waitlist_map,
+        has_active_pass=has_active_pass,
     )
 
 
-@event_bp.route('/events/signup/<int:event_id>')
+@event_bp.route('/events/signup/<int:event_id>', methods=['POST'])
 @login_required
 def signup(event_id):
     event = Event.query.get_or_404(event_id)
-    if event.spots_left <= 0:
-        flash('Nincs szabad hely.', 'danger')
-    elif EventRegistration.query.filter_by(event_id=event_id, user_id=current_user.id).first():
+    if EventRegistration.query.filter_by(
+        event_id=event_id, user_id=current_user.id, status='active'
+    ).first():
         flash('Már jelentkeztél erre az eseményre.', 'warning')
-    else:
-        reg = EventRegistration(event_id=event_id, user_id=current_user.id)
-        db.session.add(reg)
-        db.session.commit()
-        send_event_email(
-            'event_signup_user',
-            'Esemény jelentkezés',
-            event_signup_user_email(current_user.username, event),
-            current_user.email,
-        )
-        flash('Jelentkezés sikeres.', 'success')
+        return redirect(url_for('events.events'))
+
+    if event.spots_left <= 0:
+        flash('Az esemény teltházas, csatlakozz a várólistához.', 'warning')
+        return redirect(url_for('events.events'))
+
+    registration_type = request.form.get('registration_type', 'single')
+    preferred_pass_id = request.form.get('pass_id', type=int)
+    selected_pass = None
+    if registration_type == 'pass':
+        selected_pass = _get_available_pass(current_user, preferred_pass_id)
+        if not selected_pass:
+            flash('Nincs elérhető bérleted a jelentkezéshez.', 'danger')
+            return redirect(url_for('events.events'))
+
+    waitlist_entry = EventWaitlist.query.filter_by(
+        event_id=event_id, user_id=current_user.id
+    ).first()
+    if waitlist_entry:
+        db.session.delete(waitlist_entry)
+
+    registration = EventRegistration(
+        event_id=event_id,
+        user_id=current_user.id,
+        registration_type='pass' if selected_pass else 'single',
+    )
+    if selected_pass:
+        registration.pass_id = selected_pass.id
+        registration.pass_usage_id = _handle_pass_usage(selected_pass)
+    db.session.add(registration)
+    db.session.commit()
+
+    send_event_email(
+        'event_signup_user',
+        'Esemény jelentkezés',
+        event_signup_user_email(current_user.username, event),
+        current_user.email,
+    )
+    flash('Jelentkezés sikeres.', 'success')
     return redirect(url_for('events.events'))
 
 
-@event_bp.route('/events/unregister/<int:event_id>')
+@event_bp.route('/events/unregister/<int:event_id>', methods=['POST'])
 @login_required
 def unregister(event_id):
-    reg = EventRegistration.query.filter_by(event_id=event_id, user_id=current_user.id).first_or_404()
-    event = reg.event
-    db.session.delete(reg)
+    registration = EventRegistration.query.filter_by(
+        event_id=event_id, user_id=current_user.id, status='active'
+    ).first()
+    waitlist_entry = EventWaitlist.query.filter_by(
+        event_id=event_id, user_id=current_user.id
+    ).first()
+
+    if not registration and not waitlist_entry:
+        flash('Nem találtunk aktív jelentkezést.', 'warning')
+        return redirect(url_for('events.events'))
+
+    if registration:
+        late_cancel = _cancel_registration(registration)
+        event = Event.query.get(event_id)
+        send_event_email(
+            'event_unregister_user',
+            'Esemény leiratkozás',
+            event_unregister_user_email(current_user.username, event),
+            current_user.email,
+        )
+        if late_cancel and registration.registration_type == 'pass':
+            flash('48 órán belül mondtad le, az alkalom levonva marad.', 'warning')
+        else:
+            flash('Jelentkezés törölve.', 'success')
+        _promote_waitlist(event_id)
+    else:
+        db.session.delete(waitlist_entry)
+        db.session.commit()
+        flash('Eltávolítva a várólistáról.', 'success')
+
+    return redirect(url_for('events.events'))
+
+
+@event_bp.route('/events/waitlist/<int:event_id>', methods=['POST'])
+@login_required
+def join_waitlist(event_id):
+    event = Event.query.get_or_404(event_id)
+
+    if EventRegistration.query.filter_by(
+        event_id=event_id, user_id=current_user.id, status='active'
+    ).first():
+        flash('Már jelentkeztél erre az eseményre.', 'warning')
+        return redirect(url_for('events.events'))
+
+    if event.spots_left > 0:
+        flash('Még van szabad hely, jelentkezz közvetlenül.', 'info')
+        return redirect(url_for('events.events'))
+
+    if EventWaitlist.query.filter_by(
+        event_id=event_id, user_id=current_user.id
+    ).first():
+        flash('Már szerepelsz a várólistán.', 'warning')
+        return redirect(url_for('events.events'))
+
+    registration_type = request.form.get('registration_type', 'single')
+    preferred_pass_id = request.form.get('pass_id', type=int)
+    entry_kwargs = {
+        'event_id': event_id,
+        'user_id': current_user.id,
+        'registration_type': 'single',
+    }
+    if registration_type == 'pass':
+        selected_pass = _get_available_pass(current_user, preferred_pass_id)
+        if not selected_pass:
+            flash('Nincs elérhető bérleted a várólistához.', 'danger')
+            return redirect(url_for('events.events'))
+        entry_kwargs['registration_type'] = 'pass'
+        entry_kwargs['pass_id'] = selected_pass.id
+
+    waitlist_entry = EventWaitlist(**entry_kwargs)
+    db.session.add(waitlist_entry)
     db.session.commit()
-    send_event_email(
-        'event_unregister_user',
-        'Esemény leiratkozás',
-        event_unregister_user_email(current_user.username, event),
-        current_user.email,
-    )
-    flash('Jelentkezés törölve.', 'success')
+    flash('Feliratkoztál a várólistára.', 'success')
+    return redirect(url_for('events.events'))
+
+
+@event_bp.route('/events/waitlist/remove/<int:event_id>', methods=['POST'])
+@login_required
+def leave_waitlist(event_id):
+    entry = EventWaitlist.query.filter_by(
+        event_id=event_id, user_id=current_user.id
+    ).first_or_404()
+    db.session.delete(entry)
+    db.session.commit()
+    flash('Eltávolítva a várólistáról.', 'success')
     return redirect(url_for('events.events'))
 
 
@@ -112,14 +353,9 @@ def unregister(event_id):
 def admin_events():
     if current_user.role != 'admin':
         return redirect(url_for('events.events'))
-    start, end = _get_two_week_range()
-    events = (
-        Event.query.filter(Event.start_time >= start, Event.start_time <= end)
-        .order_by(Event.start_time)
-        .all()
-    )
+    events = Event.query.order_by(Event.start_time).all()
     users = User.query.all()
-    return render_template('admin_events.html', events=events, users=users, start=start, end=end)
+    return render_template('admin_events.html', events=events, users=users)
 
 
 @event_bp.route('/admin/events/create', methods=['GET', 'POST'])
@@ -137,7 +373,11 @@ def create_event():
             end_time=end_dt,
             capacity=form.capacity.data,
             color=form.color.data,
+            price=form.price.data if form.price.data is not None else None,
         )
+        image_path = _save_event_image(form.image.data)
+        if image_path:
+            event.image_path = image_path
         db.session.add(event)
         db.session.commit()
         flash('Esemény létrehozva.', 'success')
@@ -148,7 +388,6 @@ def create_event():
 @event_bp.route('/admin/events/<int:event_id>/edit', methods=['GET', 'POST'])
 @login_required
 def edit_event(event_id):
-    """Edit an existing event."""
     if current_user.role != 'admin':
         return redirect(url_for('events.events'))
 
@@ -159,18 +398,24 @@ def edit_event(event_id):
         form.date.data = event.start_time.date()
         form.start_time.data = event.start_time.time()
         form.end_time.data = event.end_time.time()
+        if event.price is not None:
+            form.price.data = float(event.price)
 
     if form.validate_on_submit():
+        event.name = form.name.data
         event.start_time = datetime.combine(form.date.data, form.start_time.data)
         event.end_time = datetime.combine(form.date.data, form.end_time.data)
         event.capacity = form.capacity.data
         event.color = form.color.data
+        event.price = form.price.data if form.price.data is not None else None
+        image_path = _save_event_image(form.image.data)
+        if image_path:
+            event.image_path = image_path
         db.session.commit()
         flash('Esemény frissítve.', 'success')
-        return redirect(url_for('events.admin_events'))
+        return redirect(url_for('events.admin_events', _anchor=f'event-{event_id}'))
 
-    users = User.query.all()
-    return render_template('edit_event.html', form=form, event=event, users=users)
+    return render_template('edit_event.html', form=form, event=event)
 
 
 @event_bp.route('/admin/events/add_user/<int:event_id>', methods=['POST'])
@@ -179,64 +424,109 @@ def add_user(event_id):
     if current_user.role != 'admin':
         return redirect(url_for('events.events'))
     user_id = request.form.get('user_id', type=int)
+    registration_type = request.form.get('registration_type', 'single')
+    user = User.query.get_or_404(user_id)
     event = Event.query.get_or_404(event_id)
+
     if event.spots_left <= 0:
         flash('Nincs szabad hely.', 'danger')
-    elif EventRegistration.query.filter_by(event_id=event_id, user_id=user_id).first():
-        flash('A felhasználó már jelentkezett.', 'warning')
-    else:
-        reg = EventRegistration(event_id=event_id, user_id=user_id)
-        db.session.add(reg)
-        db.session.commit()
-        user = User.query.get(user_id)
-        if user:
-            send_event_email(
-                'event_signup_admin',
-                'Esemény jelentkezés',
-                event_signup_admin_email(user.username, event),
-                user.email,
-            )
-        flash('Felhasználó hozzáadva.', 'success')
+        return redirect(url_for('events.admin_events', _anchor=f'event-{event_id}'))
 
-    next_page = request.args.get('next')
-    if next_page == 'edit':
-        return redirect(url_for('events.edit_event', event_id=event_id))
+    if EventRegistration.query.filter_by(
+        event_id=event_id, user_id=user_id, status='active'
+    ).first():
+        flash('A felhasználó már jelentkezett.', 'warning')
+        return redirect(url_for('events.admin_events', _anchor=f'event-{event_id}'))
+
+    selected_pass = None
+    if registration_type == 'pass':
+        selected_pass = _get_available_pass(user)
+        if not selected_pass:
+            flash('A felhasználónak nincs aktív bérlete.', 'danger')
+            return redirect(url_for('events.admin_events', _anchor=f'event-{event_id}'))
+
+    registration = EventRegistration(
+        event_id=event_id,
+        user_id=user_id,
+        registration_type='pass' if selected_pass else 'single',
+    )
+    if selected_pass:
+        registration.pass_id = selected_pass.id
+        registration.pass_usage_id = _handle_pass_usage(selected_pass)
+    db.session.add(registration)
+    db.session.commit()
+
+    send_event_email(
+        'event_signup_admin',
+        'Esemény jelentkezés',
+        event_signup_admin_email(user.username, event),
+        user.email,
+    )
+    flash('Felhasználó hozzáadva.', 'success')
     return redirect(url_for('events.admin_events', _anchor=f'event-{event_id}'))
 
 
 @event_bp.route('/admin/events/remove_user/<int:event_id>/<int:user_id>', methods=['POST'])
 @login_required
 def remove_user(event_id, user_id):
-    """Remove a user's registration from an event."""
     if current_user.role != 'admin':
         return redirect(url_for('events.events'))
-    reg = EventRegistration.query.filter_by(event_id=event_id, user_id=user_id).first_or_404()
-    event = reg.event
-    user = reg.user
-    db.session.delete(reg)
-    db.session.commit()
-    if user:
-        send_event_email(
-            'event_unregister_admin',
-            'Esemény leiratkozás',
-            event_unregister_admin_email(user.username, event),
-            user.email,
-        )
+    registration = EventRegistration.query.filter_by(
+        event_id=event_id, user_id=user_id, status='active'
+    ).first_or_404()
+    _cancel_registration(registration, force_late=False)
+    event = registration.event
+    user = registration.user
+    send_event_email(
+        'event_unregister_admin',
+        'Esemény leiratkozás',
+        event_unregister_admin_email(user.username, event),
+        user.email,
+    )
     flash('Felhasználó eltávolítva.', 'success')
-    next_page = request.args.get('next')
-    if next_page == 'edit':
-        return redirect(url_for('events.edit_event', event_id=event_id))
+    _promote_waitlist(event_id)
+    return redirect(url_for('events.admin_events', _anchor=f'event-{event_id}'))
+
+
+@event_bp.route('/admin/events/waitlist/promote/<int:event_id>/<int:entry_id>', methods=['POST'])
+@login_required
+def promote_waitlist(event_id, entry_id):
+    if current_user.role != 'admin':
+        return redirect(url_for('events.events'))
+
+    entry = EventWaitlist.query.filter_by(id=entry_id, event_id=event_id).first_or_404()
+    event = Event.query.get_or_404(event_id)
+
+    if _promote_waitlist_entry(entry, event, remove_on_fail=False):
+        flash('Felhasználó átsorolva az eseményre.', 'success')
+    else:
+        flash('Az átsorolás nem sikerült. Ellenőrizd a bérletet vagy a férőhelyeket.', 'danger')
+    return redirect(url_for('events.admin_events', _anchor=f'event-{event_id}'))
+
+
+@event_bp.route('/admin/events/waitlist/remove/<int:event_id>/<int:entry_id>', methods=['POST'])
+@login_required
+def remove_waitlist_entry(event_id, entry_id):
+    if current_user.role != 'admin':
+        return redirect(url_for('events.events'))
+    entry = EventWaitlist.query.filter_by(id=entry_id, event_id=event_id).first_or_404()
+    db.session.delete(entry)
+    db.session.commit()
+    flash('Várólista jelentkezés törölve.', 'success')
     return redirect(url_for('events.admin_events', _anchor=f'event-{event_id}'))
 
 
 @event_bp.route('/admin/events/delete/<int:event_id>', methods=['POST'])
 @login_required
 def delete_event(event_id):
-    """Delete an entire event."""
     if current_user.role != 'admin':
         return redirect(url_for('events.events'))
     event = Event.query.get_or_404(event_id)
+    for registration in list(event.registrations):
+        if registration.status == 'active':
+            _cancel_registration(registration, force_late=False)
+    EventWaitlist.query.filter_by(event_id=event_id).delete(synchronize_session=False)
     db.session.delete(event)
     db.session.commit()
     flash('Esemény törölve.', 'success')
-    return redirect(url_for('events.admin_events', _anchor=f'event-{event_id}'))
+    return redirect(url_for('events.admin_events'))

--- a/app/routes/user_routes.py
+++ b/app/routes/user_routes.py
@@ -1,6 +1,12 @@
-from flask import Blueprint, render_template, redirect, url_for, request
+from datetime import date, timedelta
+
+from flask import Blueprint, render_template, redirect, url_for, request, flash
 from flask_login import login_required, current_user
+
 from ..models import Pass, User, db
+from ..forms import PurchasePassForm
+from ..utils import send_event_email
+from ..email_templates import pass_created_email
 
 user_bp = Blueprint('user', __name__)
 
@@ -21,3 +27,35 @@ def toggle_reminder():
     db.session.commit()
     next_url = request.referrer or url_for('user.dashboard')
     return redirect(next_url)
+
+
+@user_bp.route('/passes/purchase', methods=['GET', 'POST'])
+@login_required
+def purchase_pass():
+    if current_user.role == 'admin':
+        return redirect(url_for('user.dashboard'))
+
+    form = PurchasePassForm()
+    if form.validate_on_submit():
+        uses = int(form.pass_type.data)
+        start = date.today()
+        end = start + timedelta(days=90)
+        new_pass = Pass(
+            type=f"{uses} alkalmas bérlet",
+            start_date=start,
+            end_date=end,
+            total_uses=uses,
+            used=0,
+            user_id=current_user.id,
+        )
+        db.session.add(new_pass)
+        db.session.commit()
+        send_event_email(
+            'pass_created',
+            'Új bérlet',
+            pass_created_email(new_pass),
+            current_user.email,
+        )
+        flash('Bérlet sikeresen megvásárolva.', 'success')
+        return redirect(url_for('user.dashboard'))
+    return render_template('purchase_pass.html', form=form)

--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -16,54 +16,17 @@
     font-weight: bold;
 }
 
-.calendar-table td {
-    width: 100px;
-    height: 60px;
-    vertical-align: top;
-    position: relative;
-    padding: 0;
-}
-
-.calendar-event {
-    position: absolute;
-    left: 0;
-    right: 0;
-    background-color: #0d6efd;
-    color: #fff;
-    font-size: 0.75rem;
-    padding: 2px;
-    border-radius: 2px;
+.event-ticket {
+    border: none;
+    border-radius: 12px;
     overflow: hidden;
 }
 
-.calendar-event.with-text {
-    overflow: visible;
-    z-index: 1;
+.event-ticket-image {
+    height: 180px;
+    object-fit: cover;
 }
 
-/* Colors for admin event cards based on status */
-.event-card.past {
-    background-color: #f8d7da;
-}
-.event-card.ongoing {
-    background-color: #fff3cd;
-}
-.event-card.upcoming {
-    background-color: #d1e7dd;
-}
-
-/* Background colors for calendar columns */
-.calendar-table th.weekday,
-.calendar-table td.weekday {
-    background-color: #e9f4ff; /* light blue */
-}
-
-.calendar-table th.saturday,
-.calendar-table td.saturday {
-    background-color: #fff9e6; /* light yellow */
-}
-
-.calendar-table th.sunday,
-.calendar-table td.sunday {
-    background-color: #ffe6e6; /* light red */
+.event-ticket .card-body {
+    background-color: #ffffff;
 }

--- a/app/templates/admin_events.html
+++ b/app/templates/admin_events.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html>
 <html lang="hu">
 <head>
     <meta charset="UTF-8">
@@ -18,33 +17,155 @@
         </div>
     </nav>
     <div class="container mt-4">
-        <h3>Események ({{ start }} - {{ end }})</h3>
-        <a href="{{ url_for('events.create_event') }}" class="btn btn-success btn-sm mb-3">Új esemény</a>
-        <div class="row">
+        {% with messages = get_flashed_messages(with_categories=True) %}
+        {% if messages %}
+        <div class="mb-3">
+            {% for category, message in messages %}
+            <div class="alert alert-{{ 'info' if category == 'message' else category }} alert-dismissible fade show" role="alert">
+                {{ message }}
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Bezárás"></button>
+            </div>
+            {% endfor %}
+        </div>
+        {% endif %}
+        {% endwith %}
+        <div class="d-flex justify-content-between align-items-center mb-3">
+            <h3 class="mb-0">Események</h3>
+            <a href="{{ url_for('events.create_event') }}" class="btn btn-success btn-sm">Új esemény</a>
+        </div>
+        <div class="row g-4">
         {% for e in events %}
-            <div class="col-12 col-md-6">
-                <div class="card mb-3 event-card {{ e.status }}" id="event-{{ e.id }}">
+            <div class="col-12">
+                <div class="card event-ticket" id="event-{{ e.id }}">
+                    {% if e.image_path %}
+                    <img src="{{ url_for('static', filename=e.image_path) }}" class="card-img-top event-ticket-image" alt="{{ e.name }}">
+                    {% endif %}
                     <div class="card-body">
-                        <h5 class="card-title">{{ e.name }}</h5>
-                        <p class="card-text">{{ e.formatted_time }}</p>
-                        <p class="card-text">Szabad hely: {{ e.spots_left }} / {{ e.capacity }}</p>
-                        <p class="card-text"><strong>Jelentkezők:</strong><br>
-                            {% for reg in e.registrations %}
-                                {{ reg.user.username }}{% if not loop.last %}, {% endif %}
-                            {% else %}
-                                nincs
-                            {% endfor %}
-                        </p>
-                        <a href="{{ url_for('events.edit_event', event_id=e.id) }}" class="btn btn-secondary btn-sm mb-2">Szerkesztés</a>
-                        <form method="post" action="{{ url_for('events.delete_event', event_id=e.id) }}">
-                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                            <button class="btn btn-danger btn-sm" type="submit">Esemény törlése</button>
-                        </form>
+                        <div class="d-flex justify-content-between align-items-start flex-column flex-md-row">
+                            <div>
+                                <h5 class="card-title">{{ e.name }}</h5>
+                                <p class="mb-1">{{ e.formatted_time }}</p>
+                                <p class="mb-1">Kapacitás: {{ e.spots_left }} / {{ e.capacity }}</p>
+                                {% if e.price is not none %}
+                                <p class="mb-1">Ár: {{ '{:,.0f}'.format(e.price).replace(',', ' ') }} Ft</p>
+                                {% endif %}
+                                <p class="text-muted mb-0">Várólistán: {{ e.waitlist_entries|length }} fő</p>
+                            </div>
+                            <div class="mt-3 mt-md-0 text-md-end">
+                                <a href="{{ url_for('events.edit_event', event_id=e.id) }}" class="btn btn-secondary btn-sm">Szerkesztés</a>
+                                <form method="post" action="{{ url_for('events.delete_event', event_id=e.id) }}" class="d-inline ms-1">
+                                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                    <button class="btn btn-danger btn-sm" type="submit">Esemény törlése</button>
+                                </form>
+                            </div>
+                        </div>
+                        <hr>
+                        {% set active_regs = e.registrations|selectattr('status', 'equalto', 'active')|list %}
+                        {% set cancelled_regs = e.registrations|rejectattr('status', 'equalto', 'active')|list %}
+                        <div class="row">
+                            <div class="col-md-4">
+                                <h6>Aktív jelentkezők</h6>
+                                <ul class="list-group list-group-flush">
+                                    {% for reg in active_regs %}
+                                    <li class="list-group-item d-flex justify-content-between align-items-center">
+                                        <span>{{ reg.user.username }}{% if reg.registration_type == 'pass' %} <span class="badge bg-primary ms-2">Bérlet</span>{% endif %}</span>
+                                        <form method="post" action="{{ url_for('events.remove_user', event_id=e.id, user_id=reg.user.id) }}">
+                                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                            <button class="btn btn-sm btn-outline-danger">Eltávolítás</button>
+                                        </form>
+                                    </li>
+                                    {% else %}
+                                    <li class="list-group-item">Nincs aktív jelentkező.</li>
+                                    {% endfor %}
+                                </ul>
+                            </div>
+                            <div class="col-md-4">
+                                <h6>Várólista</h6>
+                                <ul class="list-group list-group-flush">
+                                    {% for entry in e.waitlist_entries|sort(attribute='created_at') %}
+                                    <li class="list-group-item">
+                                        <div class="d-flex justify-content-between align-items-center">
+                                            <div>
+                                                {{ entry.user.username }}
+                                                {% if entry.registration_type == 'pass' %}
+                                                <span class="badge bg-primary ms-2">Bérlet</span>
+                                                {% else %}
+                                                <span class="badge bg-secondary ms-2">Alkalom</span>
+                                                {% endif %}
+                                                <div class="small text-muted">{{ entry.created_at.strftime('%Y-%m-%d %H:%M') }}</div>
+                                            </div>
+                                            <div class="d-flex">
+                                                <form method="post" action="{{ url_for('events.promote_waitlist', event_id=e.id, entry_id=entry.id) }}">
+                                                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                                    <button class="btn btn-sm btn-success me-1" type="submit">Átsorolás</button>
+                                                </form>
+                                                <form method="post" action="{{ url_for('events.remove_waitlist_entry', event_id=e.id, entry_id=entry.id) }}">
+                                                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                                    <button class="btn btn-sm btn-outline-danger" type="submit">Törlés</button>
+                                                </form>
+                                            </div>
+                                        </div>
+                                    </li>
+                                    {% else %}
+                                    <li class="list-group-item">Nincs várólista.</li>
+                                    {% endfor %}
+                                </ul>
+                            </div>
+                            <div class="col-md-4">
+                                <h6>Múltbeli státuszok</h6>
+                                <ul class="list-group list-group-flush">
+                                    {% for reg in cancelled_regs %}
+                                    <li class="list-group-item">
+                                        {{ reg.user.username }} - {{ 'késői lemondás' if reg.status == 'late_cancelled' else 'lemondva' }}
+                                        {% if reg.registration_type == 'pass' %}
+                                        <span class="badge bg-primary ms-1">Bérlet</span>
+                                        {% endif %}
+                                        {% if reg.cancelled_at %}
+                                        <div class="small text-muted">{{ reg.cancelled_at.strftime('%Y-%m-%d %H:%M') }}</div>
+                                        {% endif %}
+                                    </li>
+                                    {% else %}
+                                    <li class="list-group-item">Nincs lemondott jelentkezés.</li>
+                                    {% endfor %}
+                                </ul>
+                            </div>
+                        </div>
+                        <hr>
+                        <div class="row g-3 align-items-end">
+                            <div class="col-md-6">
+                                <form method="post" action="{{ url_for('events.add_user', event_id=e.id) }}">
+                                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                    <div class="mb-2">
+                                        <label class="form-label">Felhasználó</label>
+                                        <select name="user_id" class="form-select" required>
+                                            <option value="">-- Válassz felhasználót --</option>
+                                            {% for user in users %}
+                                                <option value="{{ user.id }}">{{ user.username }}</option>
+                                            {% endfor %}
+                                        </select>
+                                    </div>
+                                    <div class="mb-2">
+                                        <label class="form-label">Jelentkezés típusa</label>
+                                        <select name="registration_type" class="form-select">
+                                            <option value="single">Alkalmi</option>
+                                            <option value="pass">Bérlet</option>
+                                        </select>
+                                    </div>
+                                    <button class="btn btn-primary btn-sm" type="submit">Felhasználó hozzáadása</button>
+                                </form>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>
         {% endfor %}
+        {% if events|length == 0 %}
+            <div class="col-12">
+                <div class="alert alert-info">Nincs létrehozott esemény.</div>
+            </div>
+        {% endif %}
         </div>
     </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/app/templates/create_event.html
+++ b/app/templates/create_event.html
@@ -10,14 +10,16 @@
 <body class="bg-light">
     <div class="container mt-5">
         <h3>Új esemény</h3>
-        <form method="POST">
+        <form method="POST" enctype="multipart/form-data">
             {{ form.hidden_tag() }}
             <div class="mb-3">{{ form.name.label }} {{ form.name(class="form-control") }}</div>
             <div class="mb-3">{{ form.date.label }} {{ form.date(class="form-control", type="date") }}</div>
             <div class="mb-3">{{ form.start_time.label }} {{ form.start_time(class="form-control", type="time") }}</div>
             <div class="mb-3">{{ form.end_time.label }} {{ form.end_time(class="form-control", type="time") }}</div>
             <div class="mb-3">{{ form.capacity.label }} {{ form.capacity(class="form-control") }}</div>
+            <div class="mb-3">{{ form.price.label }} {{ form.price(class="form-control", placeholder="0") }}</div>
             <div class="mb-3">{{ form.color.label }} {{ form.color(class="form-select") }}</div>
+            <div class="mb-3">{{ form.image.label }} {{ form.image(class="form-control") }}</div>
             <div class="mb-3">{{ form.submit(class="btn btn-primary") }}</div>
         </form>
     </div>

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -37,10 +37,11 @@
         {% endif %}
         <div class="mb-3">
             {% if user.role == 'admin' %}
-            <a href="{{ url_for('events.admin_events') }}" class="btn btn-warning btn-sm">Időpontok</a>
-            <a href="{{ url_for('events.events') }}" class="btn btn-warning btn-sm ms-2">Naptár</a>
+            <a href="{{ url_for('events.admin_events') }}" class="btn btn-warning btn-sm">Események kezelése</a>
+            <a href="{{ url_for('events.events') }}" class="btn btn-warning btn-sm ms-2">Események</a>
             {% else %}
-            <a href="{{ url_for('events.events') }}" class="btn btn-warning btn-sm">Időpontok</a>
+            <a href="{{ url_for('events.events') }}" class="btn btn-warning btn-sm">Események</a>
+            <a href="{{ url_for('user.purchase_pass') }}" class="btn btn-success btn-sm ms-2">Bérlet vásárlása</a>
             {% endif %}
         </div>
         <div class="row">

--- a/app/templates/edit_event.html
+++ b/app/templates/edit_event.html
@@ -11,40 +11,22 @@
     <div class="container mt-5">
         <h3>Esemény szerkesztése</h3>
         <a href="{{ url_for('events.admin_events') }}" class="btn btn-secondary btn-sm mb-3">Vissza az eseményekhez</a>
-        <form method="POST">
+        <form method="POST" enctype="multipart/form-data">
             {{ form.hidden_tag() }}
-            <div class="mb-3">
-                <label class="form-label">Név</label>
-                <input type="text" class="form-control" value="{{ event.name }}" disabled>
-            </div>
+            <div class="mb-3">{{ form.name.label }} {{ form.name(class="form-control") }}</div>
             <div class="mb-3">{{ form.date.label }} {{ form.date(class="form-control", type="date") }}</div>
             <div class="mb-3">{{ form.start_time.label }} {{ form.start_time(class="form-control", type="time") }}</div>
             <div class="mb-3">{{ form.end_time.label }} {{ form.end_time(class="form-control", type="time") }}</div>
             <div class="mb-3">{{ form.capacity.label }} {{ form.capacity(class="form-control") }}</div>
+            <div class="mb-3">{{ form.price.label }} {{ form.price(class="form-control", placeholder="0") }}</div>
             <div class="mb-3">{{ form.color.label }} {{ form.color(class="form-select") }}</div>
+            <div class="mb-3">
+                {{ form.image.label }} {{ form.image(class="form-control") }}
+                {% if event.image_path %}
+                <img src="{{ url_for('static', filename=event.image_path) }}" class="img-fluid mt-2 rounded" style="max-height: 200px;" alt="{{ event.name }}">
+                {% endif %}
+            </div>
             <div class="mb-3">{{ form.submit(class="btn btn-primary") }}</div>
-        </form>
-        <hr>
-        <h5>Jelentkezők</h5>
-        <p>
-            {% for reg in event.registrations %}
-                <form method="post" action="{{ url_for('events.remove_user', event_id=event.id, user_id=reg.user.id, next='edit') }}" class="d-inline-flex align-items-center me-2">
-                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                    <span class="me-1">{{ reg.user.username }}</span>
-                    <button type="submit" class="btn btn-sm btn-link text-danger p-0">Töröl</button>
-                </form>
-            {% else %}
-                nincs
-            {% endfor %}
-        </p>
-        <form method="post" action="{{ url_for('events.add_user', event_id=event.id, next='edit') }}" class="d-flex mb-2">
-            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-            <select name="user_id" class="form-select form-select-sm me-2">
-                {% for u in users %}
-                <option value="{{ u.id }}">{{ u.username }}</option>
-                {% endfor %}
-            </select>
-            <button class="btn btn-primary btn-sm" type="submit">Hozzáadás</button>
         </form>
     </div>
 </body>

--- a/app/templates/events.html
+++ b/app/templates/events.html
@@ -17,65 +17,104 @@
             </div>
         </div>
     </nav>
-    <div class="container mt-4">
-        <h3>Események ({{ start }} - {{ end }})</h3>
-        <table class="table table-bordered calendar-table">
-            <thead>
-                <tr>
-                    <th>Óra</th>
-                    {% set day_names = ['Hétfő', 'Kedd', 'Szerda', 'Csütörtök', 'Péntek', 'Szombat', 'Vasárnap'] %}
-                    {% for day in days %}
-                        {% set cls = 'weekday' %}
-                        {% if day.weekday() == 5 %}
-                            {% set cls = 'saturday' %}
-                        {% elif day.weekday() == 6 %}
-                            {% set cls = 'sunday' %}
+    <div class="container py-4">
+        {% with messages = get_flashed_messages(with_categories=True) %}
+        {% if messages %}
+        <div class="mb-3">
+            {% for category, message in messages %}
+            <div class="alert alert-{{ 'info' if category == 'message' else category }} alert-dismissible fade show" role="alert">
+                {{ message }}
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Bezárás"></button>
+            </div>
+            {% endfor %}
+        </div>
+        {% endif %}
+        {% endwith %}
+        <div class="d-flex align-items-center mb-3">
+            <h2 class="mb-0">Események</h2>
+            <span class="badge bg-secondary ms-3">Várólistán: {{ waitlist_map|length }}</span>
+        </div>
+        <div class="row g-4">
+            {% for event in events %}
+            <div class="col-12 col-md-6 col-lg-4">
+                <div class="card h-100 shadow-sm event-ticket">
+                    {% if event.image_path %}
+                    <img src="{{ url_for('static', filename=event.image_path) }}" class="card-img-top event-ticket-image" alt="{{ event.name }}">
+                    {% endif %}
+                    <div class="card-body d-flex flex-column">
+                        <h5 class="card-title">{{ event.name }}</h5>
+                        <p class="card-text mb-1">{{ event.formatted_time }}</p>
+                        <p class="card-text mb-1">Szabad helyek: {{ event.spots_left }} / {{ event.capacity }}</p>
+                        {% if event.price is not none %}
+                        <p class="card-text mb-1">Ár: {{ '{:,.0f}'.format(event.price).replace(',', ' ') }} Ft</p>
                         {% endif %}
-                        <th class="{{ cls }}">{{ day.strftime('%m-%d') }} {{ day_names[day.weekday()] }}</th>
-                    {% endfor %}
-                </tr>
-            </thead>
-            <tbody>
-                {% for hour in range(24) %}
-                <tr>
-                    <th>{{ '%02d:00' % hour }}</th>
-                    {% for day in days %}
-                        {% set evs = events_map.get((loop.index0, hour), []) %}
-                        {% set cls = 'weekday' %}
-                        {% if day.weekday() == 5 %}
-                            {% set cls = 'saturday' %}
-                        {% elif day.weekday() == 6 %}
-                            {% set cls = 'sunday' %}
-                        {% endif %}
-                        <td class="{{ cls }}">
-                            {% for seg in evs %}
-                                {% set e = seg.event %}
-                                <div class="calendar-event{% if seg.is_first %} with-text{% endif %}"
-                                     style="top: {{ seg.start_minute }}px; height: {{ seg.end_minute - seg.start_minute }}px; background-color: {{ e.color_hex }};"
-                                     data-bs-toggle="popover" data-bs-trigger="hover focus" data-bs-placement="top"
-                                     data-bs-html="true" data-bs-content="{{ participants.get(e.id) }}">
-                                    {% if seg.is_first %}
-                                        {{ e.name }}
-                                        {% if registrations.get(e.id) %}
-                                            <a href="{{ url_for('events.unregister', event_id=e.id) }}" class="text-white">Leiratkozom</a>
-                                        {% elif e.spots_left > 0 %}
-                                            <a href="{{ url_for('events.signup', event_id=e.id) }}" class="text-white">Feliratkozom</a>
-                                        {% endif %}
+                        <p class="card-text text-muted">Várólistán: {{ event.waitlist_entries|length }} fő</p>
+                        {% set active_reg = active_registrations.get(event.id) %}
+                        {% set latest_reg = latest_registrations.get(event.id) %}
+                        {% set waitlist_entry = waitlist_map.get(event.id) %}
+                        <div class="mt-auto">
+                            {% if active_reg %}
+                                <form method="post" action="{{ url_for('events.unregister', event_id=event.id) }}">
+                                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                    <button class="btn btn-outline-danger w-100">Leiratkozom</button>
+                                </form>
+                                <p class="mt-2 small text-muted">48 órán belüli lemondás esetén a bérletalkalom levonva marad.</p>
+                            {% else %}
+                                {% if waitlist_entry %}
+                                    <div class="alert alert-info small" role="alert">
+                                        Várólistán vagy erre az eseményre.
+                                    </div>
+                                    <form method="post" action="{{ url_for('events.leave_waitlist', event_id=event.id) }}">
+                                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                        <button class="btn btn-outline-secondary w-100">Leiratkozás a várólistáról</button>
+                                    </form>
+                                {% elif event.spots_left > 0 %}
+                                    {% if has_active_pass %}
+                                    <form method="post" action="{{ url_for('events.signup', event_id=event.id) }}" class="mb-2">
+                                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                        <input type="hidden" name="registration_type" value="pass">
+                                        <button class="btn btn-primary w-100">Feliratkozom bérlettel</button>
+                                    </form>
                                     {% endif %}
-                                </div>
-                            {% endfor %}
-                        </td>
-                    {% endfor %}
-                </tr>
-                {% endfor %}
-            </tbody>
-        </table>
+                                    <form method="post" action="{{ url_for('events.signup', event_id=event.id) }}">
+                                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                        <input type="hidden" name="registration_type" value="single">
+                                        <button class="btn btn-outline-primary w-100">Feliratkozom alkalommal</button>
+                                    </form>
+                                {% else %}
+                                    <div class="alert alert-warning small" role="alert">
+                                        Az esemény teltházas. Jelentkezz a várólistára!
+                                    </div>
+                                    {% if has_active_pass %}
+                                    <form method="post" action="{{ url_for('events.join_waitlist', event_id=event.id) }}" class="mb-2">
+                                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                        <input type="hidden" name="registration_type" value="pass">
+                                        <button class="btn btn-primary w-100">Várólista (bérlettel)</button>
+                                    </form>
+                                    {% endif %}
+                                    <form method="post" action="{{ url_for('events.join_waitlist', event_id=event.id) }}">
+                                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                        <input type="hidden" name="registration_type" value="single">
+                                        <button class="btn btn-outline-primary w-100">Várólista (alkalom)</button>
+                                    </form>
+                                {% endif %}
+                            {% endif %}
+                            {% if latest_reg and latest_reg.status != 'active' %}
+                                <p class="mt-3 small text-muted">
+                                    Legutóbbi státusz: {{ 'késői lemondás' if latest_reg.status == 'late_cancelled' else 'lemondva' }}
+                                </p>
+                            {% endif %}
+                        </div>
+                    </div>
+                </div>
+            </div>
+            {% else %}
+            <div class="col-12">
+                <div class="alert alert-info">Jelenleg nincs meghirdetett esemény.</div>
+            </div>
+            {% endfor %}
+        </div>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-    <script>
-        document.querySelectorAll('[data-bs-toggle="popover"]').forEach(function (el) {
-            new bootstrap.Popover(el);
-        });
-    </script>
 </body>
 </html>

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -11,6 +11,18 @@
     <form method="POST" class="p-4 bg-white rounded shadow" style="width: 100%; max-width: 400px;">
         {{ form.hidden_tag() }}
         <h3 class="mb-3 text-center">Bejelentkezés</h3>
+        {% with messages = get_flashed_messages(with_categories=True) %}
+        {% if messages %}
+        <div class="mb-3">
+            {% for category, message in messages %}
+            <div class="alert alert-{{ 'info' if category == 'message' else category }} alert-dismissible fade show" role="alert">
+                {{ message }}
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Bezárás"></button>
+            </div>
+            {% endfor %}
+        </div>
+        {% endif %}
+        {% endwith %}
         <div class="mb-3">
             <input type="text" class="form-control" name="username" placeholder="Felhasználónév" required>
         </div>
@@ -21,6 +33,10 @@
         <div class="mt-2 text-center">
             <a href="{{ url_for('auth.forgot_password') }}">Elfelejtett jelszó?</a>
         </div>
+        <div class="mt-2 text-center">
+            <a href="{{ url_for('auth.register') }}">Regisztráció</a>
+        </div>
     </form>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/app/templates/purchase_pass.html
+++ b/app/templates/purchase_pass.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="hu">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Bérlet vásárlása</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
+</head>
+<body class="bg-light">
+    <div class="container py-5">
+        <div class="row justify-content-center">
+            <div class="col-12 col-md-6">
+                <div class="card shadow-sm">
+                    <div class="card-body">
+                        <h3 class="card-title mb-3">Bérlet vásárlása</h3>
+                        {% with messages = get_flashed_messages(with_categories=True) %}
+                        {% if messages %}
+                        <div class="mb-3">
+                            {% for category, message in messages %}
+                            <div class="alert alert-{{ 'info' if category == 'message' else category }} alert-dismissible fade show" role="alert">
+                                {{ message }}
+                                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Bezárás"></button>
+                            </div>
+                            {% endfor %}
+                        </div>
+                        {% endif %}
+                        {% endwith %}
+                        <form method="POST">
+                            {{ form.hidden_tag() }}
+                            <div class="mb-3">
+                                <label class="form-label">Bérlet típusa</label>
+                                {% for subfield in form.pass_type %}
+                                <div class="form-check">
+                                    {{ subfield(class_='form-check-input', id='passType' ~ loop.index) }}
+                                    <label class="form-check-label" for="passType{{ loop.index }}">{{ subfield.label.text }}</label>
+                                </div>
+                                {% endfor %}
+                                {% if form.pass_type.errors %}
+                                <div class="text-danger small mt-1">{{ form.pass_type.errors[0] }}</div>
+                                {% endif %}
+                            </div>
+                            <p class="text-muted small">A bérlet a vásárlástól számított 90 napig érvényes.</p>
+                            <button type="submit" class="btn btn-success w-100">Vásárlás</button>
+                        </form>
+                        <a href="{{ url_for('user.dashboard') }}" class="btn btn-link w-100 mt-2">Vissza a főoldalra</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/app/templates/register.html
+++ b/app/templates/register.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="hu">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Regisztráció</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
+</head>
+<body class="login-background d-flex align-items-center justify-content-center vh-100">
+    <form method="POST" class="p-4 bg-white rounded shadow" style="width: 100%; max-width: 420px;">
+        {{ form.hidden_tag() }}
+        <h3 class="mb-3 text-center">Regisztráció</h3>
+        {% with messages = get_flashed_messages(with_categories=True) %}
+        {% if messages %}
+        <div class="mb-3">
+            {% for category, message in messages %}
+            <div class="alert alert-{{ 'info' if category == 'message' else category }} alert-dismissible fade show" role="alert">
+                {{ message }}
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Bezárás"></button>
+            </div>
+            {% endfor %}
+        </div>
+        {% endif %}
+        {% endwith %}
+        <div class="mb-3">
+            {{ form.username(class_='form-control', placeholder='Felhasználónév') }}
+            {% for error in form.username.errors %}
+            <div class="text-danger small mt-1">{{ error }}</div>
+            {% endfor %}
+        </div>
+        <div class="mb-3">
+            {{ form.email(class_='form-control', placeholder='Email cím', type='email') }}
+            {% for error in form.email.errors %}
+            <div class="text-danger small mt-1">{{ error }}</div>
+            {% endfor %}
+        </div>
+        <div class="mb-3">
+            {{ form.password(class_='form-control', placeholder='Jelszó') }}
+            {% for error in form.password.errors %}
+            <div class="text-danger small mt-1">{{ error }}</div>
+            {% endfor %}
+        </div>
+        <div class="mb-3">
+            {{ form.confirm_password(class_='form-control', placeholder='Jelszó megerősítése') }}
+            {% for error in form.confirm_password.errors %}
+            <div class="text-danger small mt-1">{{ error }}</div>
+            {% endfor %}
+        </div>
+        <button type="submit" class="btn btn-primary w-100">Regisztráció</button>
+        <div class="mt-2 text-center">
+            <a href="{{ url_for('auth.login') }}">Már van fiókod? Bejelentkezés</a>
+        </div>
+    </form>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a public registration workflow with validation, dedicated template, and login feedback
- extend events with prices, images, waitlist management, late cancellation rules, and card-based listings for members and admins
- allow members to buy fixed passes, surface actions from the dashboard, and update schema utilities to create new columns automatically

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68e00a18d7d0832a9fd92a32c1f3a253