### PR TITLE
Add email confirmation workflow for user registration

### DIFF
--- a/app/email_templates.py
+++ b/app/email_templates.py
@@ -17,6 +17,16 @@ def registration_email(username: str, password: str) -> str:
     return base_email_template("Fiók létrehozva", content)
 
 
+def registration_confirmation_email(username: str, confirmation_url: str) -> str:
+    content = (
+        f"Kedves {username},<br><br>"
+        "A regisztráció befejezéséhez kattints az alábbi linkre:<br>"
+        f"<a href='{confirmation_url}'>{confirmation_url}</a><br><br>"
+        "Ha nem te kezdeményezted a regisztrációt, kérjük hagyd figyelmen kívül ezt az üzenetet."
+    )
+    return base_email_template("Regisztráció megerősítése", content)
+
+
 def forgot_password_email(username: str, password: str) -> str:
     content = (
         f"Kedves {username},<br><br>"

--- a/app/models.py
+++ b/app/models.py
@@ -116,6 +116,24 @@ class EmailSettings(db.Model):
     weekly_reminder_time = db.Column(db.Time)
 
 
+class PendingUser(db.Model):
+    """Temporary storage for users awaiting email verification."""
+
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(150), nullable=False)
+    email = db.Column(db.String(150), nullable=False)
+    password_hash = db.Column(db.String(256), nullable=False)
+    password_plain = db.Column(db.String(150))
+    token = db.Column(db.String(128), nullable=False, unique=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+    def set_password(self, password: str) -> None:
+        """Store the password in both hashed and plain form."""
+
+        self.password_hash = generate_password_hash(password)
+        self.password_plain = password
+
+
 class Event(db.Model):
     """Calendar event which users can sign up for."""
     id = db.Column(db.Integer, primary_key=True)

--- a/app/routes/auth_routes.py
+++ b/app/routes/auth_routes.py
@@ -2,10 +2,10 @@ from flask import Blueprint, render_template, redirect, url_for, flash, request
 from flask_login import login_user, logout_user, login_required, current_user
 from werkzeug.security import check_password_hash
 
-from ..models import User, db
+from ..models import User, PendingUser, db
 from ..forms import LoginForm, ForgotPasswordForm, RegistrationForm
 from ..utils import send_email
-from ..email_templates import forgot_password_email
+from ..email_templates import forgot_password_email, registration_confirmation_email
 import secrets
 
 auth_bp = Blueprint('auth', __name__)
@@ -41,14 +41,36 @@ def register():
             flash('A felhasználónév már foglalt.', 'danger')
             return render_template('register.html', form=form)
 
-        user = User(username=form.username.data, email=form.email.data)
-        user.set_password(form.password.data)
-        user.role = 'user'
-        db.session.add(user)
+        if PendingUser.query.filter_by(email=form.email.data).first():
+            flash('Már van folyamatban regisztráció ezzel az email címmel. Ellenőrizd a postafiókodat.', 'warning')
+            return render_template('register.html', form=form)
+        if PendingUser.query.filter_by(username=form.username.data).first():
+            flash('Már van folyamatban regisztráció ezzel a felhasználónévvel. Ellenőrizd a postafiókodat.', 'warning')
+            return render_template('register.html', form=form)
+
+        token = secrets.token_urlsafe(32)
+        pending_user = PendingUser(
+            username=form.username.data,
+            email=form.email.data,
+            token=token,
+        )
+        pending_user.set_password(form.password.data)
+        db.session.add(pending_user)
         db.session.commit()
-        login_user(user)
-        flash('Sikeres regisztráció. Üdvözlünk!', 'success')
-        return redirect(url_for('user.dashboard'))
+
+        confirmation_link = url_for('auth.verify_registration', token=token, _external=True)
+        if not send_email(
+            'Regisztráció megerősítése',
+            registration_confirmation_email(form.username.data, confirmation_link),
+            form.email.data,
+        ):
+            db.session.delete(pending_user)
+            db.session.commit()
+            flash('Nem sikerült a megerősítő email elküldése. Kérjük próbáld meg később.', 'danger')
+            return render_template('register.html', form=form)
+
+        flash('A regisztráció véglegesítéséhez kattints a megerősítő emailben található linkre.', 'success')
+        return redirect(url_for('auth.login'))
     return render_template('register.html', form=form)
 
 
@@ -80,6 +102,30 @@ def forgot_password():
 def logout():
     logout_user()
     return redirect(url_for('auth.login'))
+
+
+@auth_bp.route('/verify/<token>')
+def verify_registration(token):
+    pending_user = PendingUser.query.filter_by(token=token).first()
+    if not pending_user:
+        flash('A megerősítő link érvénytelen vagy már felhasználták.', 'danger')
+        return redirect(url_for('auth.register'))
+
+    if User.query.filter_by(email=pending_user.email).first() or User.query.filter_by(username=pending_user.username).first():
+        db.session.delete(pending_user)
+        db.session.commit()
+        flash('Ez a felhasználó már létezik. Jelentkezz be a fiókoddal.', 'info')
+        return redirect(url_for('auth.login'))
+
+    user = User(username=pending_user.username, email=pending_user.email, role='user')
+    user.password_hash = pending_user.password_hash
+    user.password_plain = pending_user.password_plain
+    db.session.add(user)
+    db.session.delete(pending_user)
+    db.session.commit()
+    login_user(user)
+    flash('A regisztráció sikeresen megerősítve. Üdvözlünk!', 'success')
+    return redirect(url_for('user.dashboard'))
 
 @auth_bp.route('/')
 def index():


### PR DESCRIPTION
## Summary
- introduce a PendingUser model to store registration details until confirmation
- send a verification email with a unique token before creating a user account
- add a verification route that finalizes the account only after the user clicks the email link

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e05a4d8d58832a85e3c89af617435c