### PR TITLE
Prevent registration from crashing without email validation dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ python-dotenv
 qrcode[pil]
 reportlab
 APScheduler>=3.10
+email-validator


### PR DESCRIPTION
## Summary
- add a SafeEmail validator that gracefully falls back when the optional email_validator package is unavailable
- update registration and password reset forms to use the resilient email validation helper
- list email-validator in the application requirements for environments that can install it

## Testing
- python - <<'PY'
from app import create_app
from html.parser import HTMLParser

class CSRFParser(HTMLParser):
    def __init__(self):
        super().__init__()
        self.token = None
    def handle_starttag(self, tag, attrs):
        if tag == 'input':
            attrs = dict(attrs)
            if attrs.get('id') == 'csrf_token':
                self.token = attrs.get('value')

app = create_app()
app.app_context().push()
client = app.test_client()
resp = client.get('/register')
parser = CSRFParser()
parser.feed(resp.get_data(as_text=True))
resp = client.post('/register', data={
    'csrf_token': parser.token,
    'username': 'testuser2',
    'email': 'invalid-email',
    'password': 'password',
    'confirm_password': 'password'
}, follow_redirects=False)
print('Status invalid:', resp.status_code)
print('Contains error:', 'Érvénytelen email cím' in resp.get_data(as_text=True))

resp = client.post('/register', data={
    'csrf_token': parser.token,
    'username': 'testuser3',
    'email': 'test3@example.com',
    'password': 'password',
    'confirm_password': 'password'
}, follow_redirects=False)
print('Status valid:', resp.status_code)
print('Redirect location:', resp.headers.get('Location'))
PY


------
https://chatgpt.com/codex/tasks/task_e_68e05cbd93c8832aab3934460e4fefec