### PR TITLE
Handle registration confirmation email failures gracefully

### DIFF
--- a/app/routes/auth_routes.py
+++ b/app/routes/auth_routes.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, render_template, redirect, url_for, flash, request
+from flask import Blueprint, render_template, redirect, url_for, flash, request, current_app
 from flask_login import login_user, logout_user, login_required, current_user
 from werkzeug.security import check_password_hash
 
@@ -64,10 +64,19 @@ def register():
             registration_confirmation_email(form.username.data, confirmation_link),
             form.email.data,
         ):
-            db.session.delete(pending_user)
-            db.session.commit()
-            flash('Nem sikerült a megerősítő email elküldése. Kérjük próbáld meg később.', 'danger')
-            return render_template('register.html', form=form)
+            current_app.logger.warning(
+                'Nem sikerült regisztrációs megerősítő e-mailt küldeni erre a címre: %s',
+                form.email.data,
+            )
+            flash(
+                'Nem sikerült a megerősítő email elküldése. Az alábbi link használatával tudod befejezni a regisztrációt.',
+                'warning',
+            )
+            return render_template(
+                'register.html',
+                form=form,
+                confirmation_link=confirmation_link,
+            )
 
         flash('A regisztráció véglegesítéséhez kattints a megerősítő emailben található linkre.', 'success')
         return redirect(url_for('auth.login'))

--- a/app/templates/register.html
+++ b/app/templates/register.html
@@ -23,6 +23,12 @@
         </div>
         {% endif %}
         {% endwith %}
+        {% if confirmation_link %}
+        <div class="alert alert-warning" role="alert">
+            Ha nem érkezett meg az email, másold az alábbi linket a böngésződbe a regisztráció megerősítéséhez:<br>
+            <a href="{{ confirmation_link }}" class="text-break">{{ confirmation_link }}</a>
+        </div>
+        {% endif %}
         <div class="mb-3">
             {{ form.username(class_='form-control', placeholder='Felhasználónév') }}
             {% for error in form.username.errors %}


### PR DESCRIPTION
## Summary
- keep pending registrations when the confirmation email cannot be sent
- surface the verification link on the registration page so users can still finish signup
- log failed email attempts for easier diagnostics

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68e05e22f684832aa3a3bd4944e53e2a