### PR TITLE
Implement event reminder emails and post-event pass notifications

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -169,6 +169,18 @@ def create_app():
                         "ALTER TABLE email_settings ADD COLUMN event_unregister_admin_text TEXT"
                     )
                 )
+            if 'event_reminder_enabled' not in columns:
+                conn.execute(
+                    text(
+                        "ALTER TABLE email_settings ADD COLUMN event_reminder_enabled BOOLEAN DEFAULT 0"
+                    )
+                )
+            if 'event_reminder_text' not in columns:
+                conn.execute(
+                    text(
+                        "ALTER TABLE email_settings ADD COLUMN event_reminder_text TEXT"
+                    )
+                )
             # Legacy weekly reminder columns are intentionally not created on new
             # installations now that the feature has been removed.
             insp.close()
@@ -184,6 +196,8 @@ def create_app():
                 'cancelled_at': "ALTER TABLE event_registration ADD COLUMN cancelled_at DATETIME",
                 'is_late_cancel': "ALTER TABLE event_registration ADD COLUMN is_late_cancel BOOLEAN DEFAULT 0",
                 'waitlist_promoted': "ALTER TABLE event_registration ADD COLUMN waitlist_promoted BOOLEAN DEFAULT 0",
+                'reminder_sent': "ALTER TABLE event_registration ADD COLUMN reminder_sent BOOLEAN DEFAULT 0",
+                'pass_deduction_notified': "ALTER TABLE event_registration ADD COLUMN pass_deduction_notified BOOLEAN DEFAULT 0",
             }
             for column_name, statement in registration_columns.items():
                 if column_name not in columns:

--- a/app/forms.py
+++ b/app/forms.py
@@ -136,6 +136,9 @@ class EmailSettingsForm(FlaskForm):
     event_unregister_admin_enabled = BooleanField('Leiratkozáskor (admin)')
     event_unregister_admin_text = TextAreaField('Admin leiratkoztatás üzenete')
 
+    event_reminder_enabled = BooleanField('Esemény emlékeztető (24 órával előtte)')
+    event_reminder_text = TextAreaField('Emlékeztető kiegészítő szövege')
+
     submit = SubmitField('Mentés')
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -110,6 +110,9 @@ class EmailSettings(db.Model):
     event_unregister_admin_enabled = db.Column(db.Boolean, default=False)
     event_unregister_admin_text = db.Column(db.Text)
 
+    event_reminder_enabled = db.Column(db.Boolean, default=False)
+    event_reminder_text = db.Column(db.Text)
+
     weekly_reminder_enabled = db.Column(db.Boolean, default=False)
     weekly_reminder_text = db.Column(db.Text)
     weekly_reminder_day = db.Column(db.Integer, default=0)
@@ -212,6 +215,8 @@ class EventRegistration(db.Model):
     cancelled_at = db.Column(db.DateTime)
     is_late_cancel = db.Column(db.Boolean, default=False)
     waitlist_promoted = db.Column(db.Boolean, default=False)
+    reminder_sent = db.Column(db.Boolean, default=False)
+    pass_deduction_notified = db.Column(db.Boolean, default=False)
     pass_usage = db.relationship('PassUsage', foreign_keys=[pass_usage_id])
 
 

--- a/app/routes/event_routes.py
+++ b/app/routes/event_routes.py
@@ -288,10 +288,18 @@ def unregister(event_id):
     if registration:
         late_cancel = _cancel_registration(registration)
         event = Event.query.get(event_id)
+        used_pass = registration.registration_type == 'pass'
+        deduction_kept = used_pass and (late_cancel or registration.pass_usage_id is not None)
         send_event_email(
             'event_unregister_user',
             'Esemény leiratkozás',
-            event_unregister_user_email(current_user.username, event),
+            event_unregister_user_email(
+                current_user.username,
+                event,
+                used_pass=used_pass,
+                late_cancel=late_cancel,
+                deduction_kept=deduction_kept,
+            ),
             current_user.email,
         )
         if late_cancel and registration.registration_type == 'pass':

--- a/app/templates/email_settings.html
+++ b/app/templates/email_settings.html
@@ -93,6 +93,14 @@
             {{ form.event_unregister_admin_text.label(class="form-label") }}
             {{ form.event_unregister_admin_text(class="form-control") }}
         </div>
+        <div class="form-check">
+            {{ form.event_reminder_enabled(class="form-check-input") }}
+            {{ form.event_reminder_enabled.label(class="form-check-label") }}
+        </div>
+        <div class="mb-3">
+            {{ form.event_reminder_text.label(class="form-label") }}
+            {{ form.event_reminder_text(class="form-control") }}
+        </div>
         {{ form.submit(class="btn btn-primary") }}
         <a href="{{ url_for('user.dashboard') }}" class="btn btn-secondary">Vissza</a>
     </form>

--- a/app/utils.py
+++ b/app/utils.py
@@ -71,33 +71,46 @@ def send_event_email(event, subject, default_html, to_email):
 
     if settings:
         mapping = {
-            'user_created': (settings.user_created_enabled, settings.user_created_text),
-            'user_deleted': (settings.user_deleted_enabled, settings.user_deleted_text),
-            'pass_created': (settings.pass_created_enabled, settings.pass_created_text),
-            'pass_deleted': (settings.pass_deleted_enabled, settings.pass_deleted_text),
-            'pass_used': (settings.pass_used_enabled, settings.pass_used_text),
+            'user_created': (settings.user_created_enabled, settings.user_created_text, 'prepend'),
+            'user_deleted': (settings.user_deleted_enabled, settings.user_deleted_text, 'prepend'),
+            'pass_created': (settings.pass_created_enabled, settings.pass_created_text, 'prepend'),
+            'pass_deleted': (settings.pass_deleted_enabled, settings.pass_deleted_text, 'prepend'),
+            'pass_used': (settings.pass_used_enabled, settings.pass_used_text, 'prepend'),
             'event_signup_user': (
                 settings.event_signup_user_enabled,
                 settings.event_signup_user_text,
+                'prepend',
             ),
             'event_signup_admin': (
                 settings.event_signup_admin_enabled,
                 settings.event_signup_admin_text,
+                'prepend',
             ),
             'event_unregister_user': (
                 settings.event_unregister_user_enabled,
                 settings.event_unregister_user_text,
+                'prepend',
             ),
             'event_unregister_admin': (
                 settings.event_unregister_admin_enabled,
                 settings.event_unregister_admin_text,
+                'prepend',
+            ),
+            'event_reminder': (
+                settings.event_reminder_enabled,
+                settings.event_reminder_text,
+                'append',
             ),
         }
-        enabled, custom_text = mapping.get(event, (False, None))
+        enabled, custom_text, order = mapping.get(event, (False, None, 'prepend'))
         if not enabled:
             return False
+        custom_text = (custom_text or '').strip()
         if custom_text:
-            combined = f"{custom_text}<br><br>{default_content}"
+            if order == 'append':
+                combined = f"{default_content}<br><br>{custom_text}"
+            else:
+                combined = f"{custom_text}<br><br>{default_content}"
             html = base_email_template(subject, combined)
         else:
             html = default_html

--- a/send_event_notifications.py
+++ b/send_event_notifications.py
@@ -1,0 +1,100 @@
+"""Send event reminder and pass deduction emails."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta
+
+from app import create_app, db
+from app.models import EmailSettings, Event, EventRegistration, Pass
+from app.email_templates import event_reminder_email, pass_used_email
+from app.utils import send_event_email
+
+
+def _send_event_reminders(now: datetime, settings: EmailSettings | None) -> int:
+    if not settings or not settings.event_reminder_enabled:
+        return 0
+
+    window_end = now + timedelta(hours=24)
+    registrations = (
+        EventRegistration.query.join(Event)
+        .filter(
+            EventRegistration.status == 'active',
+            EventRegistration.reminder_sent.is_(False),
+            Event.start_time > now,
+            Event.start_time <= window_end,
+        )
+        .all()
+    )
+
+    sent = 0
+    for registration in registrations:
+        event = registration.event
+        if not event:
+            continue
+        if send_event_email(
+            'event_reminder',
+            'Esemény emlékeztető',
+            event_reminder_email(event),
+            registration.user.email,
+        ):
+            registration.reminder_sent = True
+            sent += 1
+    return sent
+
+
+def _send_pass_deduction_notifications(now: datetime, settings: EmailSettings | None) -> int:
+    if not settings or not settings.pass_used_enabled:
+        return 0
+
+    registrations = (
+        EventRegistration.query.join(Event)
+        .filter(
+            Event.end_time <= now,
+            EventRegistration.pass_usage_id.isnot(None),
+            EventRegistration.pass_deduction_notified.is_(False),
+            EventRegistration.status.in_(('active', 'late_cancelled')),
+        )
+        .all()
+    )
+
+    sent = 0
+    for registration in registrations:
+        event = registration.event
+        if not event:
+            continue
+        if not registration.user:
+            continue
+        associated_pass = Pass.query.get(registration.pass_id)
+        if not associated_pass:
+            registration.pass_deduction_notified = True
+            continue
+        if send_event_email(
+            'pass_used',
+            'Bérlet használat',
+            pass_used_email(associated_pass, event),
+            registration.user.email,
+        ):
+            registration.pass_deduction_notified = True
+            sent += 1
+    return sent
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO)
+    app = create_app()
+    with app.app_context():
+        now = datetime.utcnow()
+        settings = EmailSettings.query.first()
+        reminders = _send_event_reminders(now, settings)
+        deductions = _send_pass_deduction_notifications(now, settings)
+        db.session.commit()
+        logging.info(
+            "Esemény emlékeztetők kiküldve: %s, levonási értesítők: %s",
+            reminders,
+            deductions,
+        )
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add email settings support for event reminder messages and persist reminder/pass notification flags on registrations
- send 24 hour reminder emails and defer pass deduction emails until events finish via a new scheduler script
- enrich cancellation and pass usage templates with timing and event context details

## Testing
- python -m compileall app send_event_notifications.py

------
https://chatgpt.com/codex/tasks/task_e_68e0b7c0cc2c832a97683c73af13ffdb