### PR TITLE
Set pass request expiration date to June 2026

### DIFF
--- a/app/routes/admin_routes.py
+++ b/app/routes/admin_routes.py
@@ -23,7 +23,7 @@ from ..email_templates import (
     registration_email,
     base_email_template,
 )
-from datetime import date, datetime, timedelta
+from datetime import date, datetime
 
 admin_bp = Blueprint('admin', __name__)
 
@@ -85,7 +85,7 @@ def approve_pass_request(request_id):
         return redirect(url_for('admin.pass_requests'))
 
     start = date.today()
-    end = start + timedelta(days=90)
+    end = date(2026, 6, 15)
     new_pass = Pass(
         type=pass_request.display_type,
         start_date=start,


### PR DESCRIPTION
## Summary
- set approved pass request expirations to 15 June 2026
- clean up unused timedelta import in the admin routes module

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e0c0da0454832a98c3c14d47e28120