### PR TITLE
Add waitlist promotion email messaging

### DIFF
--- a/app/email_templates.py
+++ b/app/email_templates.py
@@ -92,10 +92,18 @@ def _event_details(e) -> str:
     )
 
 
-def event_signup_user_email(username: str, e) -> str:
+def event_signup_user_email(username: str, e, from_waitlist: bool = False) -> str:
+    if from_waitlist:
+        intro = (
+            "Felszabadult egy hely a várólistán szereplő eseményen, így automatikusan "
+            "átkerültél a résztvevők közé.<br>"
+        )
+    else:
+        intro = "Sikeresen jelentkeztél a következő eseményre:<br>"
+
     content = (
         f"Kedves {username},<br><br>"
-        f"Sikeresen jelentkeztél a következő eseményre:<br>"
+        f"{intro}"
         f"{_event_details(e)}"
     )
     return base_email_template("Esemény jelentkezés", content)

--- a/app/routes/event_routes.py
+++ b/app/routes/event_routes.py
@@ -153,7 +153,7 @@ def _promote_waitlist_entry(entry, event=None, remove_on_fail=False):
     send_event_email(
         'event_signup_user',
         'Esemény jelentkezés',
-        event_signup_user_email(user.username, event),
+        event_signup_user_email(user.username, event, from_waitlist=True),
         user.email,
     )
     return True


### PR DESCRIPTION
## Summary
- extend the event signup email template to mention when a user is promoted from the waitlist
- send the updated waitlist-specific message when a user is automatically registered from the waitlist

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e2a02b4678832a87e722f0382d99e5