### PR TITLE
Send confirmation email when users join the waitlist

### DIFF
--- a/app/email_templates.py
+++ b/app/email_templates.py
@@ -109,6 +109,18 @@ def event_signup_user_email(username: str, e, from_waitlist: bool = False) -> st
     return base_email_template("Esemény jelentkezés", content)
 
 
+def event_waitlist_join_email(username: str, e) -> str:
+    """Return the email HTML confirming a waitlist registration."""
+
+    content = (
+        f"Kedves {username},<br><br>"
+        "Felkerültél a következő esemény várólistájára:<br>"
+        f"{_event_details(e)}"
+        "<br><br>Amint felszabadul egy hely, e-mailben értesítünk."
+    )
+    return base_email_template("Várólista jelentkezés", content)
+
+
 def event_signup_admin_email(username: str, e) -> str:
     content = (
         f"Kedves {username},<br><br>"

--- a/app/routes/event_routes.py
+++ b/app/routes/event_routes.py
@@ -23,12 +23,13 @@ from ..models import (
     db,
 )
 from ..forms import EventForm
-from ..utils import send_event_email
+from ..utils import send_email, send_event_email
 from ..email_templates import (
     event_signup_user_email,
     event_signup_admin_email,
     event_unregister_user_email,
     event_unregister_admin_email,
+    event_waitlist_join_email,
 )
 
 
@@ -362,6 +363,11 @@ def join_waitlist(event_id):
     waitlist_entry = EventWaitlist(**entry_kwargs)
     db.session.add(waitlist_entry)
     db.session.commit()
+    send_email(
+        'Várólista jelentkezés',
+        event_waitlist_join_email(current_user.username, event),
+        current_user.email,
+    )
     flash('Feliratkoztál a várólistára.', 'success')
     return redirect(url_for('events.events'))
 


### PR DESCRIPTION
## Summary
- add a dedicated email template that confirms a waitlist registration
- trigger the confirmation email when a user successfully joins an event's waitlist

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2a4fa6870832aa1c7a36a627bbfdd