### PR TITLE
Send email when admin removes waitlist entry

### DIFF
--- a/app/email_templates.py
+++ b/app/email_templates.py
@@ -121,6 +121,18 @@ def event_waitlist_join_email(username: str, e) -> str:
     return base_email_template("Várólista jelentkezés", content)
 
 
+def event_waitlist_removed_email(username: str, e) -> str:
+    """Return the email HTML when an admin removes a waitlist entry."""
+
+    content = (
+        f"Kedves {username},<br><br>"
+        "Az admin eltávolított a következő esemény várólistájáról:<br>"
+        f"{_event_details(e)}"
+        "<br><br>Ha további kérdésed van, lépj kapcsolatba velünk."
+    )
+    return base_email_template("Várólista eltávolítás", content)
+
+
 def event_signup_admin_email(username: str, e) -> str:
     content = (
         f"Kedves {username},<br><br>"

--- a/app/routes/event_routes.py
+++ b/app/routes/event_routes.py
@@ -30,6 +30,7 @@ from ..email_templates import (
     event_unregister_user_email,
     event_unregister_admin_email,
     event_waitlist_join_email,
+    event_waitlist_removed_email,
 )
 
 
@@ -592,8 +593,15 @@ def remove_waitlist_entry(event_id, entry_id):
     if current_user.role != 'admin':
         return redirect(url_for('events.events'))
     entry = EventWaitlist.query.filter_by(id=entry_id, event_id=event_id).first_or_404()
+    event = entry.event
+    user = entry.user
     db.session.delete(entry)
     db.session.commit()
+    send_email(
+        'Várólista eltávolítás',
+        event_waitlist_removed_email(user.username, event),
+        user.email,
+    )
     flash('Várólista jelentkezés törölve.', 'success')
     return redirect(url_for('events.admin_events', _anchor=f'event-{event_id}'))
 


### PR DESCRIPTION
## Summary
- add a dedicated email template for informing users about waitlist removals
- trigger the notification when an admin deletes someone from an event waitlist

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2a9fee518832ab7d97d2da8f6c4f4