### PR TITLE
Implement daily event reminder emails

### DIFF
--- a/send_weekly_reminders.py
+++ b/send_weekly_reminders.py
@@ -1,15 +1,69 @@
-"""Legacy entry point for the removed weekly reminder feature.
+"""Send reminder emails for events starting within the next 24 hours."""
 
-The original application scheduled this module to run periodically to send
-emails.  The customer no longer needs weekly reminders, so the script simply
-logs a short notice instead of touching the database or sending mail.
-"""
+from __future__ import annotations
 
 import logging
+from datetime import datetime, timedelta
+
+from app import create_app, db
+from app.email_templates import event_reminder_email
+from app.models import EmailSettings, Event, EventRegistration
+from app.utils import send_event_email
+
+
+def _fetch_pending_registrations(now: datetime) -> list[EventRegistration]:
+    """Return registrations that require a reminder email."""
+
+    window_end = now + timedelta(hours=24)
+    return (
+        EventRegistration.query.join(Event)
+        .filter(
+            EventRegistration.status == 'active',
+            EventRegistration.reminder_sent.is_(False),
+            Event.start_time > now,
+            Event.start_time <= window_end,
+        )
+        .all()
+    )
 
 
 def main() -> None:
-    logging.info("Weekly reminder funkció letiltva, nincs teendő.")
+    logging.basicConfig(level=logging.INFO)
+    app = create_app()
+    with app.app_context():
+        settings = EmailSettings.query.first()
+        if not settings or not settings.event_reminder_enabled:
+            logging.info(
+                "Esemény emlékeztető funkció letiltva, nincs kiküldendő e-mail."
+            )
+            return
+
+        now = datetime.utcnow()
+        registrations = _fetch_pending_registrations(now)
+        if not registrations:
+            logging.info("Nincs kiküldendő esemény emlékeztető e-mail.")
+            return
+
+        sent = 0
+        for registration in registrations:
+            event = registration.event
+            user = registration.user
+            if not event or not user or not user.email:
+                continue
+
+            if send_event_email(
+                'event_reminder',
+                'Esemény emlékeztető',
+                event_reminder_email(event),
+                user.email,
+            ):
+                registration.reminder_sent = True
+                sent += 1
+
+        db.session.commit()
+        logging.info(
+            "Esemény emlékeztetők kiküldve: %s/%s", sent, len(registrations)
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- replace the legacy weekly reminder script with a daily event reminder runner
- query upcoming registrations within 24 hours and send notification emails
- log outcomes while respecting the event reminder configuration

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2d143f998832aa1ec429e2280a4c2