### PR TITLE
Add post-event thank you emails and limit pass notifications

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -181,6 +181,18 @@ def create_app():
                         "ALTER TABLE email_settings ADD COLUMN event_reminder_text TEXT"
                     )
                 )
+            if 'event_thank_you_enabled' not in columns:
+                conn.execute(
+                    text(
+                        "ALTER TABLE email_settings ADD COLUMN event_thank_you_enabled BOOLEAN DEFAULT 0"
+                    )
+                )
+            if 'event_thank_you_text' not in columns:
+                conn.execute(
+                    text(
+                        "ALTER TABLE email_settings ADD COLUMN event_thank_you_text TEXT"
+                    )
+                )
             # Legacy weekly reminder columns are intentionally not created on new
             # installations now that the feature has been removed.
             insp.close()
@@ -198,6 +210,7 @@ def create_app():
                 'waitlist_promoted': "ALTER TABLE event_registration ADD COLUMN waitlist_promoted BOOLEAN DEFAULT 0",
                 'reminder_sent': "ALTER TABLE event_registration ADD COLUMN reminder_sent BOOLEAN DEFAULT 0",
                 'pass_deduction_notified': "ALTER TABLE event_registration ADD COLUMN pass_deduction_notified BOOLEAN DEFAULT 0",
+                'thank_you_sent': "ALTER TABLE event_registration ADD COLUMN thank_you_sent BOOLEAN DEFAULT 0",
             }
             for column_name, statement in registration_columns.items():
                 if column_name not in columns:

--- a/app/email_templates.py
+++ b/app/email_templates.py
@@ -183,6 +183,17 @@ def event_reminder_email(e) -> str:
     return base_email_template("Esemény emlékeztető", content)
 
 
+def event_thank_you_email(username: str, e) -> str:
+    """Return the thank you email sent after an event has finished."""
+    content = (
+        f"Kedves {username},<br><br>"
+        f"Köszönjük, hogy részt vettél a(z) {e.name} eseményen.<br>"
+        "Várunk vissza a következő alkalommal is!<br><br>"
+        f"{_event_details(e)}"
+    )
+    return base_email_template("Köszönjük a részvételt", content)
+
+
 def event_unregister_admin_email(username: str, e) -> str:
     """Return the email HTML when an admin removes a user from an event."""
     content = (

--- a/app/forms.py
+++ b/app/forms.py
@@ -139,6 +139,9 @@ class EmailSettingsForm(FlaskForm):
     event_reminder_enabled = BooleanField('Esemény emlékeztető (24 órával előtte)')
     event_reminder_text = TextAreaField('Emlékeztető kiegészítő szövege')
 
+    event_thank_you_enabled = BooleanField('Esemény utáni köszönő üzenet')
+    event_thank_you_text = TextAreaField('Köszönő üzenet kiegészítő szövege')
+
     submit = SubmitField('Mentés')
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -113,6 +113,9 @@ class EmailSettings(db.Model):
     event_reminder_enabled = db.Column(db.Boolean, default=False)
     event_reminder_text = db.Column(db.Text)
 
+    event_thank_you_enabled = db.Column(db.Boolean, default=False)
+    event_thank_you_text = db.Column(db.Text)
+
     weekly_reminder_enabled = db.Column(db.Boolean, default=False)
     weekly_reminder_text = db.Column(db.Text)
     weekly_reminder_day = db.Column(db.Integer, default=0)
@@ -217,6 +220,7 @@ class EventRegistration(db.Model):
     waitlist_promoted = db.Column(db.Boolean, default=False)
     reminder_sent = db.Column(db.Boolean, default=False)
     pass_deduction_notified = db.Column(db.Boolean, default=False)
+    thank_you_sent = db.Column(db.Boolean, default=False)
     pass_usage = db.relationship('PassUsage', foreign_keys=[pass_usage_id])
 
 

--- a/app/notification_tasks.py
+++ b/app/notification_tasks.py
@@ -1,0 +1,157 @@
+"""Utility functions for sending scheduled event-related emails."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta
+
+from app.email_templates import (
+    event_reminder_email,
+    event_thank_you_email,
+    pass_used_email,
+)
+from app.models import EmailSettings, Event, EventRegistration, Pass
+from app.utils import send_event_email
+
+
+def send_event_reminders(now: datetime, settings: EmailSettings | None) -> int:
+    """Send reminder e-mails for events starting within the next 24 hours."""
+
+    if not settings:
+        logging.info("Nincsenek e-mail beállítások, emlékeztetők kihagyva.")
+        return 0
+
+    if not settings.event_reminder_enabled:
+        logging.info(
+            "Esemény emlékeztető funkció letiltva, nincs kiküldendő e-mail."
+        )
+        return 0
+
+    window_end = now + timedelta(hours=24)
+    registrations = (
+        EventRegistration.query.join(Event)
+        .filter(
+            EventRegistration.status == "active",
+            EventRegistration.reminder_sent.is_(False),
+            Event.start_time > now,
+            Event.start_time <= window_end,
+        )
+        .all()
+    )
+
+    if not registrations:
+        logging.info("Nincs kiküldendő esemény emlékeztető e-mail.")
+        return 0
+
+    sent = 0
+    for registration in registrations:
+        event = registration.event
+        user = registration.user
+        if not event or not user or not user.email:
+            continue
+
+        if send_event_email(
+            "event_reminder",
+            "Esemény emlékeztető",
+            event_reminder_email(event),
+            user.email,
+        ):
+            registration.reminder_sent = True
+            sent += 1
+
+    return sent
+
+
+def send_pass_deduction_notifications(
+    now: datetime, settings: EmailSettings | None
+) -> int:
+    """Notify users about pass deductions for events that ended recently."""
+
+    if not settings:
+        logging.info("Nincsenek e-mail beállítások, bérlet értesítők kihagyva.")
+        return 0
+
+    if not settings.pass_used_enabled:
+        logging.info("Bérlet levonási értesítők kiküldése letiltva.")
+        return 0
+
+    window_start = now - timedelta(hours=36)
+    registrations = (
+        EventRegistration.query.join(Event)
+        .filter(
+            Event.end_time <= now,
+            Event.end_time >= window_start,
+            EventRegistration.pass_usage_id.isnot(None),
+            EventRegistration.pass_deduction_notified.is_(False),
+            EventRegistration.status.in_(("active", "late_cancelled")),
+        )
+        .all()
+    )
+
+    sent = 0
+    for registration in registrations:
+        event = registration.event
+        user = registration.user
+        if not event or not user or not user.email:
+            continue
+
+        associated_pass = Pass.query.get(registration.pass_id)
+        if not associated_pass:
+            registration.pass_deduction_notified = True
+            continue
+
+        if send_event_email(
+            "pass_used",
+            "Bérlet használat",
+            pass_used_email(associated_pass, event),
+            user.email,
+        ):
+            registration.pass_deduction_notified = True
+            sent += 1
+
+    return sent
+
+
+def send_event_thank_you_notifications(
+    now: datetime, settings: EmailSettings | None
+) -> int:
+    """Send thank-you e-mails to attendees without pass usage."""
+
+    if not settings:
+        logging.info("Nincsenek e-mail beállítások, köszönő üzenetek kihagyva.")
+        return 0
+
+    if not settings.event_thank_you_enabled:
+        logging.info("Köszönő e-mailek kiküldése letiltva.")
+        return 0
+
+    window_start = now - timedelta(hours=36)
+    registrations = (
+        EventRegistration.query.join(Event)
+        .filter(
+            Event.end_time <= now,
+            Event.end_time >= window_start,
+            EventRegistration.pass_usage_id.is_(None),
+            EventRegistration.thank_you_sent.is_(False),
+            EventRegistration.status == "active",
+        )
+        .all()
+    )
+
+    sent = 0
+    for registration in registrations:
+        event = registration.event
+        user = registration.user
+        if not event or not user or not user.email:
+            continue
+
+        if send_event_email(
+            "event_thank_you",
+            "Köszönjük a részvételt",
+            event_thank_you_email(user.username, event),
+            user.email,
+        ):
+            registration.thank_you_sent = True
+            sent += 1
+
+    return sent

--- a/app/templates/email_settings.html
+++ b/app/templates/email_settings.html
@@ -101,6 +101,14 @@
             {{ form.event_reminder_text.label(class="form-label") }}
             {{ form.event_reminder_text(class="form-control") }}
         </div>
+        <div class="form-check">
+            {{ form.event_thank_you_enabled(class="form-check-input") }}
+            {{ form.event_thank_you_enabled.label(class="form-check-label") }}
+        </div>
+        <div class="mb-3">
+            {{ form.event_thank_you_text.label(class="form-label") }}
+            {{ form.event_thank_you_text(class="form-control") }}
+        </div>
         {{ form.submit(class="btn btn-primary") }}
         <a href="{{ url_for('user.dashboard') }}" class="btn btn-secondary">Vissza</a>
     </form>

--- a/app/utils.py
+++ b/app/utils.py
@@ -101,6 +101,11 @@ def send_event_email(event, subject, default_html, to_email):
                 settings.event_reminder_text,
                 'append',
             ),
+            'event_thank_you': (
+                settings.event_thank_you_enabled,
+                settings.event_thank_you_text,
+                'prepend',
+            ),
         }
         enabled, custom_text, order = mapping.get(event, (False, None, 'prepend'))
         if not enabled:

--- a/send_event_notifications.py
+++ b/send_event_notifications.py
@@ -3,116 +3,15 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime
 
 from app import create_app, db
-from app.models import EmailSettings, Event, EventRegistration, Pass
-from app.email_templates import event_reminder_email, event_thank_you_email, pass_used_email
-from app.utils import send_event_email
-
-
-def _send_event_reminders(now: datetime, settings: EmailSettings | None) -> int:
-    if not settings or not settings.event_reminder_enabled:
-        return 0
-
-    window_end = now + timedelta(hours=24)
-    registrations = (
-        EventRegistration.query.join(Event)
-        .filter(
-            EventRegistration.status == 'active',
-            EventRegistration.reminder_sent.is_(False),
-            Event.start_time > now,
-            Event.start_time <= window_end,
-        )
-        .all()
-    )
-
-    sent = 0
-    for registration in registrations:
-        event = registration.event
-        if not event:
-            continue
-        if send_event_email(
-            'event_reminder',
-            'Esemény emlékeztető',
-            event_reminder_email(event),
-            registration.user.email,
-        ):
-            registration.reminder_sent = True
-            sent += 1
-    return sent
-
-
-def _send_pass_deduction_notifications(now: datetime, settings: EmailSettings | None) -> int:
-    if not settings or not settings.pass_used_enabled:
-        return 0
-
-    window_start = now - timedelta(hours=36)
-    registrations = (
-        EventRegistration.query.join(Event)
-        .filter(
-            Event.end_time <= now,
-            Event.end_time >= window_start,
-            EventRegistration.pass_usage_id.isnot(None),
-            EventRegistration.pass_deduction_notified.is_(False),
-            EventRegistration.status.in_(('active', 'late_cancelled')),
-        )
-        .all()
-    )
-
-    sent = 0
-    for registration in registrations:
-        event = registration.event
-        if not event:
-            continue
-        if not registration.user:
-            continue
-        associated_pass = Pass.query.get(registration.pass_id)
-        if not associated_pass:
-            registration.pass_deduction_notified = True
-            continue
-        if send_event_email(
-            'pass_used',
-            'Bérlet használat',
-            pass_used_email(associated_pass, event),
-            registration.user.email,
-        ):
-            registration.pass_deduction_notified = True
-            sent += 1
-    return sent
-
-
-def _send_event_thank_you_notifications(now: datetime, settings: EmailSettings | None) -> int:
-    if not settings or not settings.event_thank_you_enabled:
-        return 0
-
-    window_start = now - timedelta(hours=36)
-    registrations = (
-        EventRegistration.query.join(Event)
-        .filter(
-            Event.end_time <= now,
-            Event.end_time >= window_start,
-            EventRegistration.pass_usage_id.is_(None),
-            EventRegistration.thank_you_sent.is_(False),
-            EventRegistration.status == 'active',
-        )
-        .all()
-    )
-
-    sent = 0
-    for registration in registrations:
-        event = registration.event
-        if not event or not registration.user:
-            continue
-        if send_event_email(
-            'event_thank_you',
-            'Köszönjük a részvételt',
-            event_thank_you_email(registration.user.username, event),
-            registration.user.email,
-        ):
-            registration.thank_you_sent = True
-            sent += 1
-    return sent
+from app.models import EmailSettings
+from app.notification_tasks import (
+    send_event_reminders,
+    send_event_thank_you_notifications,
+    send_pass_deduction_notifications,
+)
 
 
 def main() -> None:
@@ -121,9 +20,9 @@ def main() -> None:
     with app.app_context():
         now = datetime.utcnow()
         settings = EmailSettings.query.first()
-        reminders = _send_event_reminders(now, settings)
-        deductions = _send_pass_deduction_notifications(now, settings)
-        thank_yous = _send_event_thank_you_notifications(now, settings)
+        reminders = send_event_reminders(now, settings)
+        deductions = send_pass_deduction_notifications(now, settings)
+        thank_yous = send_event_thank_you_notifications(now, settings)
         db.session.commit()
         logging.info(
             "Esemény emlékeztetők kiküldve: %s, levonási értesítők: %s, köszönő üzenetek: %s",

--- a/send_event_notifications.py
+++ b/send_event_notifications.py
@@ -1,4 +1,4 @@
-"""Send event reminder and pass deduction emails."""
+"""Send event reminder, pass deduction, and thank you emails."""
 
 from __future__ import annotations
 
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta
 
 from app import create_app, db
 from app.models import EmailSettings, Event, EventRegistration, Pass
-from app.email_templates import event_reminder_email, pass_used_email
+from app.email_templates import event_reminder_email, event_thank_you_email, pass_used_email
 from app.utils import send_event_email
 
 
@@ -47,10 +47,12 @@ def _send_pass_deduction_notifications(now: datetime, settings: EmailSettings | 
     if not settings or not settings.pass_used_enabled:
         return 0
 
+    window_start = now - timedelta(hours=36)
     registrations = (
         EventRegistration.query.join(Event)
         .filter(
             Event.end_time <= now,
+            Event.end_time >= window_start,
             EventRegistration.pass_usage_id.isnot(None),
             EventRegistration.pass_deduction_notified.is_(False),
             EventRegistration.status.in_(('active', 'late_cancelled')),
@@ -80,6 +82,39 @@ def _send_pass_deduction_notifications(now: datetime, settings: EmailSettings | 
     return sent
 
 
+def _send_event_thank_you_notifications(now: datetime, settings: EmailSettings | None) -> int:
+    if not settings or not settings.event_thank_you_enabled:
+        return 0
+
+    window_start = now - timedelta(hours=36)
+    registrations = (
+        EventRegistration.query.join(Event)
+        .filter(
+            Event.end_time <= now,
+            Event.end_time >= window_start,
+            EventRegistration.pass_usage_id.is_(None),
+            EventRegistration.thank_you_sent.is_(False),
+            EventRegistration.status == 'active',
+        )
+        .all()
+    )
+
+    sent = 0
+    for registration in registrations:
+        event = registration.event
+        if not event or not registration.user:
+            continue
+        if send_event_email(
+            'event_thank_you',
+            'Köszönjük a részvételt',
+            event_thank_you_email(registration.user.username, event),
+            registration.user.email,
+        ):
+            registration.thank_you_sent = True
+            sent += 1
+    return sent
+
+
 def main() -> None:
     logging.basicConfig(level=logging.INFO)
     app = create_app()
@@ -88,11 +123,13 @@ def main() -> None:
         settings = EmailSettings.query.first()
         reminders = _send_event_reminders(now, settings)
         deductions = _send_pass_deduction_notifications(now, settings)
+        thank_yous = _send_event_thank_you_notifications(now, settings)
         db.session.commit()
         logging.info(
-            "Esemény emlékeztetők kiküldve: %s, levonási értesítők: %s",
+            "Esemény emlékeztetők kiküldve: %s, levonási értesítők: %s, köszönő üzenetek: %s",
             reminders,
             deductions,
+            thank_yous,
         )
 
 


### PR DESCRIPTION
## Summary
- add schema support and settings fields for post-event thank-you emails
- send separate thank-you emails to non-pass participants and restrict pass notifications to 36 hours
- extend email templates and notification script to cover the new workflow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2d7f14534832ab140287defa0e516