### PR TITLE
Add user blacklist management for event access

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -12,6 +12,7 @@ class User(UserMixin, db.Model):
     # required for the current application logic.
     password_plain = db.Column(db.String(150))
     role = db.Column(db.String(10), nullable=False, default='user')  # 'admin' or 'user'
+    is_blacklisted = db.Column(db.Boolean, nullable=False, default=False)
     # Delete associated passes when a user is removed so foreign key
     # constraints don't raise an ``IntegrityError``.
     passes = db.relationship(

--- a/app/templates/blacklist.html
+++ b/app/templates/blacklist.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="hu">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Feketelista</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
+</head>
+<body class="bg-light">
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+        <div class="container-fluid">
+            <a class="navbar-brand" href="#">Bérletkezelő</a>
+            <div class="d-flex">
+                <a class="btn btn-outline-light btn-sm" href="{{ url_for('user.dashboard') }}">Vissza a főoldalra</a>
+                <a class="btn btn-outline-light btn-sm ms-2" href="/logout">Kilépés</a>
+            </div>
+        </div>
+    </nav>
+    <div class="container py-4">
+        <h2>Feketelista kezelése</h2>
+        <p class="text-muted">Itt tudod a felhasználókat feketelistára tenni vagy onnan eltávolítani. Az érintett felhasználók nem jelentkezhetnek eseményekre.</p>
+
+        {% with messages = get_flashed_messages(with_categories=True) %}
+        {% if messages %}
+        <div class="mb-3">
+            {% for category, message in messages %}
+            <div class="alert alert-{{ 'info' if category == 'message' else category }} alert-dismissible fade show" role="alert">
+                {{ message }}
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Bezárás"></button>
+            </div>
+            {% endfor %}
+        </div>
+        {% endif %}
+        {% endwith %}
+
+        <div class="row g-4">
+            <div class="col-12 col-lg-6">
+                <div class="card shadow-sm h-100">
+                    <div class="card-body">
+                        <h4 class="card-title">Feketelistán lévő felhasználók</h4>
+                        {% if blacklisted_users %}
+                        <div class="list-group">
+                            {% for user in blacklisted_users %}
+                            <div class="list-group-item d-flex justify-content-between align-items-center">
+                                <div>
+                                    <strong>{{ user.username }}</strong>
+                                    <div class="small text-muted">{{ user.email }}</div>
+                                </div>
+                                <form method="post" action="{{ url_for('admin.remove_from_blacklist', user_id=user.id) }}">
+                                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                    <button class="btn btn-outline-success btn-sm">Eltávolítás</button>
+                                </form>
+                            </div>
+                            {% endfor %}
+                        </div>
+                        {% else %}
+                        <p class="text-muted mb-0">Jelenleg nincs felhasználó a feketelistán.</p>
+                        {% endif %}
+                    </div>
+                </div>
+            </div>
+            <div class="col-12 col-lg-6">
+                <div class="card shadow-sm h-100">
+                    <div class="card-body">
+                        <h4 class="card-title">Felhasználók hozzáadása</h4>
+                        {% if available_users %}
+                        <div class="list-group">
+                            {% for user in available_users %}
+                            <div class="list-group-item d-flex justify-content-between align-items-center">
+                                <div>
+                                    <strong>{{ user.username }}</strong>
+                                    <div class="small text-muted">{{ user.email }}</div>
+                                </div>
+                                <form method="post" action="{{ url_for('admin.add_to_blacklist', user_id=user.id) }}">
+                                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                    <button class="btn btn-outline-danger btn-sm">Feketelistára</button>
+                                </form>
+                            </div>
+                            {% endfor %}
+                        </div>
+                        {% else %}
+                        <p class="text-muted mb-0">Nincs olyan felhasználó, aki még ne lenne feketelistán vagy admin jogosultságú.</p>
+                        {% endif %}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -19,6 +19,11 @@
     </nav>
     <div class="container mt-5">
         <h2>Üdvözlünk, {{ user.username }}!</h2>
+        {% if user.is_blacklisted %}
+        <div class="alert alert-dark mt-3" role="alert">
+            Jelenleg feketelistán vagy, így nem tudsz új eseményre jelentkezni.
+        </div>
+        {% endif %}
         {% if user.role == 'admin' %}
         <div class="mb-3">
             <a href="{{ url_for('admin.create_pass') }}" class="btn btn-success btn-sm">Új bérlet</a>
@@ -27,6 +32,7 @@
             <a href="{{ url_for('admin.backup') }}" class="btn btn-danger btn-sm">Backup</a>
             <a href="{{ url_for('admin.restore') }}" class="btn btn-info btn-sm">Restore</a>
             <a href="{{ url_for('admin.pass_requests') }}" class="btn btn-warning btn-sm">Bérlet igénylések</a>
+            <a href="{{ url_for('admin.blacklist') }}" class="btn btn-dark btn-sm">Feketelista</a>
         </div>
         {% endif %}
         <div class="mb-3">

--- a/app/templates/events.html
+++ b/app/templates/events.html
@@ -34,6 +34,11 @@
             <h2 class="mb-0">Események</h2>
             <span class="badge bg-secondary ms-3">Várólistán: {{ waitlist_map|length }}</span>
         </div>
+        {% if user_blacklisted %}
+        <div class="alert alert-dark" role="alert">
+            Feketelistán szerepelsz, ezért nem tudsz új eseményre jelentkezni vagy várólistára feliratkozni.
+        </div>
+        {% endif %}
         <div class="row g-4">
             {% for event in events %}
             <div class="col-12 col-md-6 col-lg-4">
@@ -79,6 +84,10 @@
                                         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                                         <button class="btn btn-outline-secondary w-100">Leiratkozás a várólistáról</button>
                                     </form>
+                                    {% elif user_blacklisted %}
+                                    <div class="alert alert-dark small" role="alert">
+                                        Nem jelentkezhetsz erre az eseményre, mert feketelistán vagy.
+                                    </div>
                                     {% elif event.spots_left > 0 %}
                                     <form method="post" action="{{ url_for('events.signup', event_id=event.id) }}" class="mb-2">
                                         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">


### PR DESCRIPTION
## Summary
- add an `is_blacklisted` flag to users and expose admin pages to manage the blacklist
- block blacklisted users from signing up or being promoted to events while showing clear UI messaging
- surface blacklist status in the dashboard and events views with a dedicated management page for admins

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68e4a70dfcdc832abe22f6ec49b4e9c6