### PR TITLE
Fix admin login crash for legacy databases

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -89,6 +89,17 @@ def create_app():
                         "ALTER TABLE user ADD COLUMN weekly_reminder_opt_in BOOLEAN DEFAULT 0"
                     )
                 )
+            # Older databases also pre-date the introduction of the
+            # ``is_blacklisted`` flag. Without the column every query against the
+            # ``user`` table raises ``sqlite3.OperationalError: no such column:
+            # user.is_blacklisted`` which prevented administrators from logging
+            # in. Ensure the column exists so role checks work reliably.
+            if 'is_blacklisted' not in columns:
+                conn.execute(
+                    text(
+                        "ALTER TABLE user ADD COLUMN is_blacklisted BOOLEAN DEFAULT 0"
+                    )
+                )
             insp.close()
 
             insp = conn.execute(text("PRAGMA table_info(event)"))


### PR DESCRIPTION
## Summary
- ensure the legacy schema upgrade also backfills the `is_blacklisted` column on the user table
- document why the column is required so old databases stop throwing `sqlite3.OperationalError` when admins sign in

## Testing
- python - <<'PY'
import sqlite3
from pathlib import Path
from app import create_app, db
from app.models import User
Path('instance').mkdir(exist_ok=True)
legacy = Path('instance/legacy.db')
if legacy.exists():
    legacy.unlink()
conn = sqlite3.connect(legacy)
cur = conn.cursor()
cur.execute('CREATE TABLE user (id INTEGER PRIMARY KEY, username TEXT, email TEXT, password_hash TEXT, role TEXT, password_plain TEXT)')
conn.commit()
conn.close()
app = create_app()
app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///legacy.db'
app.config['TESTING'] = True
app.config['WTF_CSRF_ENABLED'] = False
with app.app_context():
    admin = User(username='admin', email='admin@example.com', role='admin')
    admin.set_password('admin123')
    db.session.add(admin)
    db.session.commit()
client = app.test_client()
response = client.post('/login', data={'username': 'admin', 'password': 'admin123'})
assert response.status_code == 302 and response.headers['Location'] == '/dashboard'
PY

------
https://chatgpt.com/codex/tasks/task_e_68e4acaa6c4c832a8b02c0947f8dedd2